### PR TITLE
Added native menu components

### DIFF
--- a/ui/native-menu/menu-item.js
+++ b/ui/native-menu/menu-item.js
@@ -7,6 +7,8 @@
 var Montage = require("montage/core/core").Montage,
     defaultEventManager = require("montage/core/event/event-manager").defaultEventManager;
 
+var kListenerError = "'menuAction' listener must be installed on a component or the Application object";
+
 exports.MenuItem = Montage.create(Montage, {
 
     _title: {
@@ -72,7 +74,6 @@ exports.MenuItem = Montage.create(Montage, {
         set: function(value) {
             this._enabled = value;
             if (this.menu && !this._nativeLock) {
-                if (this.title == "Montage")
                 lumieres.MenuItem.setEnabled.call(this, value);
             }
         }
@@ -95,12 +96,8 @@ exports.MenuItem = Montage.create(Montage, {
         }
     },
 
-    insertAfter: {
-        value: undefined
-    },
-
-    insertBefore: {
-        value: undefined
+    location: {
+        value: null
     },
 
     deserializedFromSerialization: {
@@ -113,12 +110,13 @@ exports.MenuItem = Montage.create(Montage, {
 
     addEventListener: {
         value: function(type, listener, useCapture) {
-            throw new Error("To listen on menuAction, add your listener either on a UI or the Application component");
+            throw new Error("addEventListener not supported. " + kListenerError);
         }
     },
 
     removeEventListener: {
         value: function(type, listener, useCapture) {
+            throw new Error("removeEventListener not supported. " + kListenerError);
         }
     }
 


### PR DESCRIPTION
This is an initial implementation, more work is due to complete it at later time...
Here is an example how to define a new menu:

```
            "item1": {
                "prototype": "client/ui/native-menu/menu-item",
                "properties": {
                    "title": "Hello",
                    "identifier": "hello",
                    "keyEquivalent": "meta+shift+h"
                }
            },

            "item2": {
                "prototype": "client/ui/native-menu/menu-item",
                "properties": {
                    "title": "World",
                    "keyEquivalent": "meta+shift+w"
                }
            },

            "menu1": {
                "prototype": "client/ui/native-menu/menu-item",
                "properties": {
                    "title": "Montage",
                    "items": [
                        {"@":"item1"},
                        {"@":"item2"}
                    ],
                    "location": {"after":"4"}
                },
                "bindings": {
                    "title": {"<->": "@title.value"},
                    "enabled": {"<->": "@enabled.checked"}
                }
            },

            "mainmenu": {
                "prototype": "client/ui/native-menu/menu[defaultMenu]",
                "properties": {
                    "item": {"#": "main"},
                    "resetMenuWhenInitializing": true,
                    "items": [
                       {"@":"menu1"}
                    ]
                }
            },

            "application": {
                "listeners": [
                    {
                        "type": "menuAction",
                        "listener": {"@": "owner"}
                    }
                ]
            },
```
