### PR TITLE
Add notion of backend services which are loaded dynamically on startup

### DIFF
--- a/backend_plugins/lumieres.js
+++ b/backend_plugins/lumieres.js
@@ -1,0 +1,27 @@
+var path = require("path"),
+    fs = require("fs");
+
+exports.getPlugins = function() {
+    var result = [],
+        parentPath = path.join(global.clientPath, "plugins");
+
+    if (fs.existsSync(parentPath)) {
+        var list = fs.readdirSync(parentPath);
+
+        for (var i in list) {
+            var fileName = list[i];
+            // For now accept any file that ends with .js
+            if (path.extname(fileName).toLowerCase() == ".js") {
+                result.push("fs:/" + path.join(parentPath, fileName));
+            }
+        }
+    }
+
+    return result;
+};
+
+exports.createApplication = function(url) {
+    // TODO: Write me!
+    console.log("--- createApplication", url);
+    return null;
+};

--- a/core/lumieres-bridge.js
+++ b/core/lumieres-bridge.js
@@ -158,7 +158,7 @@ exports.LumiereBridge = Montage.create(EnvironmentBridge, {
     open: {
         value: function (url) {
             var backend = Connection(new WebSocket("ws://localhost:" + lumieres.nodePort));
-            return backend.get("lumieres").invoke("openDocument", url);
+            return backend.get("application").invoke("openDocument", url);
         }
     },
 


### PR DESCRIPTION
Filament now have a folder named backed_plugins in which filament can add js file to extend the websocket cababilities. the name of the js file will become to the name of the property to get in order to invoke a method.

Note: filament is now responsible to provides any dependencies needed by a backend extension like q-io

You will need lumieres's backend-services branch to test those chances. As soon this pull re
