### PR TITLE
Remove component's reference to element

### DIFF
--- a/test/core/reel-document-template-editing-spec.js
+++ b/test/core/reel-document-template-editing-spec.js
@@ -157,6 +157,25 @@ describe("core/reel-document-headless-editing-spec", function () {
             }).timeout(WAITSFOR_TIMEOUT);
         });
 
+        it("should undo the removal of a template node with a next sibling by adding it back on the position", function () {
+            return reelDocumentPromise.then(function (reelDocument) {
+                var element = reelDocument.htmlDocument.getElementById("removeMe");
+                var nodeProxy = reelDocument.nodeProxyForNode(element);
+
+                var parentNode = nodeProxy.parentNode;
+                var nextSibling = nodeProxy.nextSibling;
+                var previousSibling = nodeProxy.previousSibling;
+
+                reelDocument.removeTemplateNode(nodeProxy);
+
+                return reelDocument.undoManager.undo().then(function() {
+                    expect(nodeProxy.parentNode).toBe(parentNode);
+                    expect(nodeProxy.nextSibling).toBe(nextSibling);
+                    expect(nodeProxy.previousSibling).toBe(previousSibling);
+                });
+            }).timeout(WAITSFOR_TIMEOUT);
+        });
+
         it("should add an undo operation for removing a node without a next sibling", function () {
             return reelDocumentPromise.then(function (reelDocument) {
                 var element = reelDocument.htmlDocument.getElementById("removeLastNode"),
@@ -220,6 +239,17 @@ describe("core/reel-document-headless-editing-spec", function () {
             }).timeout(WAITSFOR_TIMEOUT);
         });
 
+        it("should remove the component reference to the node", function () {
+            return reelDocumentPromise.then(function (reelDocument) {
+                var element = reelDocument.htmlDocument.getElementById("foo");
+                var nodeProxy = reelDocument.nodeProxyForNode(element);
+                var component = nodeProxy.component;
+
+                reelDocument.removeTemplateNode(nodeProxy);
+
+                expect(component.properties.get("element")).toBeUndefined();
+            }).timeout(WAITSFOR_TIMEOUT);
+        });
     });
 
     describe("removing a subtree", function () {


### PR DESCRIPTION
When a node is removed from the template we also need to remove the component reference if it exists.
Caveat: Montage complains about instantiating a component's template without an element but is expected and it doesn't affect the filament's operation.
