### PR TITLE
Fix issue with changing ReelProxy's element

### DIFF
--- a/core/node-proxy.js
+++ b/core/node-proxy.js
@@ -7,7 +7,15 @@ exports.NodeProxy = NodeProxy = Montage.specialize({
         value: function NodeProxy() {
             this.super();
 
-            this.addPathChangeListener("_editingDocument.editingProxies", this, "handleEditingProxiesChange");
+            this.defineBindings({
+                // The node proxy's component is the editing proxy that has this
+                // node as an element.
+                "component": {"<-": "_editingDocument.editingProxies.filter{properties.get('element') == $self}[0]"}
+            }, {
+                parameters: {
+                    self: this
+                }
+            });
         }
     },
 
@@ -189,18 +197,6 @@ exports.NodeProxy = NodeProxy = Montage.specialize({
             }
 
             return nodeProxy;
-        }
-    },
-
-    handleEditingProxiesChange: {
-        value: function() {
-            if (this._editingDocument) {
-                var component = this._editingDocument.componentProxyForElement(this);
-
-                if (component !== this.component) {
-                    this.component = component;
-                }
-            }
         }
     }
 });

--- a/test/all.js
+++ b/test/all.js
@@ -1,5 +1,6 @@
 require("montage-testing").run(require, [
     // Please keep in alphabetical order
+    "test/core/node-proxy-spec",
     "test/core/project-controller-file-spec",
     "test/core/project-controller-spec",
     "test/core/reel-context-spec",

--- a/test/core/node-proxy-spec.js
+++ b/test/core/node-proxy-spec.js
@@ -1,0 +1,65 @@
+var Montage = require("montage").Montage,
+    Promise = require("montage/core/promise").Promise,
+    mockReelDocument = require("test/mocks/reel-document-mocks").mockReelDocument,
+    NodeProxy = require("core/node-proxy").NodeProxy,
+    WAITSFOR_TIMEOUT = 2500;
+
+describe("core/node-proxy-spec", function () {
+
+    var reelDocumentPromise;
+
+    beforeEach(function () {
+        reelDocumentPromise = mockReelDocument("foo/bar/mock.reel", {
+            "owner": {
+                "properties": {
+                    "element": {"#": "ownerElement"}
+                }
+            },
+            "foo": {
+                "prototype": "ui/foo.reel",
+                "properties": {
+                    "element": {"#": "foo"}
+                }
+            },
+            "bar": {
+                "prototype": "ui/bar.reel",
+                "properties": {
+                }
+            }
+        }, '<div data-montage-id="ownerElement"><div data-montage-id="foo" id="foo"></div><div data-montage-id="bar" id="bar"></div></div>');
+    });
+
+    describe("component property", function() {
+        it("should reference the component that references the node as the element property", function() {
+            return reelDocumentPromise.then(function (reelDocument) {
+                var nodeProxy = reelDocument.nodeProxyForMontageId("foo"),
+                    reelProxy = reelDocument.editingProxyMap["foo"];
+
+                expect(reelProxy.properties.get("element")).toBe(nodeProxy);
+            }).timeout(WAITSFOR_TIMEOUT);
+        });
+
+        it("should update when the component stops referencing the node", function() {
+            return reelDocumentPromise.then(function (reelDocument) {
+                var nodeProxy = reelDocument.nodeProxyForMontageId("foo"),
+                    reelProxy = reelDocument.editingProxyMap["foo"],
+                    barNodeProxy = reelDocument.nodeProxyForMontageId("bar");
+
+                reelProxy.properties.set("element", barNodeProxy);
+
+                expect(nodeProxy.component).toBeUndefined();
+            }).timeout(WAITSFOR_TIMEOUT);
+        });
+
+        it("should update when the a component starts referencing the node", function() {
+            return reelDocumentPromise.then(function (reelDocument) {
+                var nodeProxy = reelDocument.nodeProxyForMontageId("bar"),
+                    reelProxy = reelDocument.editingProxyMap["bar"];
+
+                reelProxy.properties.set("element", nodeProxy);
+
+                expect(nodeProxy.component).toBe(reelProxy);
+            }).timeout(WAITSFOR_TIMEOUT);
+        });
+    });
+});


### PR DESCRIPTION
NodeProxy was only observing changes in the ReelDocument's list of ReelProxys. This meant that if a ReelProxy had its properties.get("element") changed it would not be picked up by the NodeProxy.

Changing the observer into a binding makes sure that a NodeProxy is always pointing to the right component no matter how the change happened (new ReelProxy in the list or a change in the element).
