### PR TITLE
add a way to edit an existing listener entry

### DIFF
--- a/core/reel-document.js
+++ b/core/reel-document.js
@@ -1051,6 +1051,20 @@ exports.ReelDocument = EditingDocument.specialize({
         }
     },
 
+    _addOwnedObjectEventListener: {
+        value: function (proxy, listener, insertionIndex) {
+
+            var addedListener = proxy.addEventListener(listener, insertionIndex);
+
+            if (addedListener) {
+                this.undoManager.register("Define Listener", Promise.resolve([this.removeOwnedObjectEventListener, this, proxy, listener]));
+            }
+
+            return addedListener;
+
+        }
+    },
+
     cancelOwnedObjectBinding: {
         value: function (proxy, binding) {
             var removedBinding,
@@ -1116,16 +1130,39 @@ exports.ReelDocument = EditingDocument.specialize({
                 //     // TODO register the listener on the stage, make sure we can remove it later
                 // }
 
-                this.undoManager.register("Add Listener", Promise.resolve([this.removeOwnedObjectEventListener, this, proxy, listenerEntry]));
+                this.undoManager.register("Define Listener", Promise.resolve([this.removeOwnedObjectEventListener, this, proxy, listenerEntry]));
             }
 
             return listenerEntry;
         }
     },
 
+    updateOwnedObjectEventListener: {
+        value: function (proxy, existingListener, type, listener, useCapture) {
+            var originalType = existingListener.type,
+                originalListener = existingListener.listener,
+                originalUseCapture = existingListener.useCapture,
+                updatedListener;
+
+            updatedListener = proxy.updateObjectEventListener(existingListener, type, listener, useCapture);
+
+            if (updatedListener) {
+                this.undoManager.register("Edit Listener", Promise.resolve([this.updateOwnedObjectEventListener, this, proxy, updatedListener, originalType, originalListener, originalUseCapture]));
+            }
+
+            return updatedListener;
+        }
+    },
+
     removeOwnedObjectEventListener: {
         value: function (proxy, listener) {
-            var removedListener = proxy.removeObjectEventListener(listener);
+            var removedListener,
+                removedIndex,
+                removedInfo;
+
+            removedInfo = proxy.removeObjectEventListener(listener);
+            removedListener = removedInfo.removedListener;
+            removedIndex = removedInfo.index;
 
             if (removedListener) {
                 // if (this._editingController) {
@@ -1133,7 +1170,7 @@ exports.ReelDocument = EditingDocument.specialize({
                 // }
 
                 this.undoManager.register("Remove Listener", Promise.resolve([
-                    this.addOwnedObjectEventListener, this, proxy, removedListener.type, removedListener.listener, removedListener.useCapture
+                    this._addOwnedObjectEventListener, this, proxy, removedListener, removedIndex
                 ]));
             }
 

--- a/core/reel-proxy.js
+++ b/core/reel-proxy.js
@@ -291,6 +291,29 @@ var ReelProxy = exports.ReelProxy = EditingProxy.specialize( {
     },
 
     /**
+     * Add a specified listener object to the proxy at a specific index
+     * in the listeners collection, used for undoability not new listeners
+     */
+    addEventListener: {
+        value: function (listener, insertionIndex) {
+            var listenerIndex = this.listeners.indexOf(listener);
+
+            if (-1 === listenerIndex) {
+                if (isNaN(insertionIndex)) {
+                    this.listeners.push(listener);
+                } else {
+                    this.listeners.splice(insertionIndex, 0, listener);
+                }
+            } else {
+                //TODO guard against adding exact same listener to multiple proxies
+                throw new Error("Cannot add the same listener to a proxy more than once");
+            }
+
+            return listener;
+        }
+    },
+
+    /**
      * Remove the specific binding from the set of active bindings on this proxy
      *
      * @return {Object} an object with two keys index and removedBinding
@@ -324,6 +347,41 @@ var ReelProxy = exports.ReelProxy = EditingProxy.specialize( {
         }
     },
 
+    /**
+     * Update an existing listener with new parameters
+     *
+     * All parameters are required, currently you cannot update a single
+     * property of the existing listener without affecting the others.
+     *
+     * @param {Object} listener The existing listener to update
+     * @param {string} type 
+     * @param {Object} itsListener 
+     * @param {string} useCapture 
+     */
+    updateObjectEventListener: {
+        value: function (listener, type, itsListener, useCapture) {
+            var existinglistener,
+                listenerIndex = this.listeners.indexOf(listener);
+
+            if (listenerIndex > -1) {
+                existinglistener = listener;
+            } else {
+                throw new Error("Cannot update a listener that's not associated with this proxy.");
+            }
+
+            listener.type = type;
+            listener.listener = itsListener;
+            listener.useCapture = useCapture;
+
+            return listener;
+        }
+    },
+
+    /**
+     * Remove the specific listener from the set of active listeners on this proxy
+     *
+     * @return {Object} an object with two keys index and removedListener
+     */
     removeObjectEventListener: {
         value: function (listener) {
             var removedListener,
@@ -331,10 +389,10 @@ var ReelProxy = exports.ReelProxy = EditingProxy.specialize( {
 
             if (listenerIndex > -1) {
                 this.listeners.splice(listenerIndex, 1);
-                removedListener = listener;
+                return {index: listenerIndex, removedListener: listener};
+            } else {
+                throw new Error("Cannot remove a listener that's not associated with this proxy");
             }
-
-            return removedListener;
         }
     }
 

--- a/test/core/reel-document-headless-editing-spec.js
+++ b/test/core/reel-document-headless-editing-spec.js
@@ -531,7 +531,7 @@ describe("core/reel-document-headless-editing-spec", function () {
             }).timeout(WAITSFOR_TIMEOUT);
         });
 
-        it ("should define the binding on the specified  object", function () {
+        it ("should define the binding on the specified object", function () {
             return reelDocumentPromise.then(function (reelDocument) {
                 var targetProxy = reelDocument.editingProxyMap.foo;
                 var binding = reelDocument.defineOwnedObjectBinding(targetProxy, targetPath, oneway, sourcePath);
@@ -591,13 +591,14 @@ describe("core/reel-document-headless-editing-spec", function () {
             }).timeout(WAITSFOR_TIMEOUT);
         });
 
-        it ("should undo the removal of a listener by defining a similar listener", function () {
+        it ("should undo the removal of a listener by restoring the same listener", function () {
             return reelDocumentPromise.then(function (reelDocument) {
                 var targetProxy = reelDocument.editingProxyMap.foo;
                 var listener = targetProxy.listeners[0];
 
                 reelDocument.removeOwnedObjectEventListener(targetProxy, listener);
                 return reelDocument.undo().then(function (addedListener) {
+                    expect(addedListener).toBe(listener);
                     expect(addedListener.type).toBe(listener.type);
                     expect(addedListener.listener).toBe(listener.listener);
                     expect(addedListener.useCapture).toBe(listener.useCapture);
@@ -606,9 +607,82 @@ describe("core/reel-document-headless-editing-spec", function () {
             }).timeout(WAITSFOR_TIMEOUT);
         });
 
+        it ("should undo the removal of a listener by restoring the same listener at the same index", function () {
+            return reelDocumentPromise.then(function (reelDocument) {
+                var targetProxy = reelDocument.editingProxyMap.foo;
+                var listener = targetProxy.listeners[0];
+
+                //Pad the listeners collection
+                targetProxy.listeners.push("foo");
+                targetProxy.listeners.push("bar");
+
+                reelDocument.removeOwnedObjectEventListener(targetProxy, listener);
+                return reelDocument.undo().then(function (addedListener) {
+                    expect(targetProxy.listeners.indexOf(addedListener)).toBe(0);
+                });
+
+            }).timeout(WAITSFOR_TIMEOUT);
+        });
+
+        describe("when considering a series of undoable operations", function () {
+
+            it ("should successfully perform an editing undo after undoing the removal of a listener", function () {
+                return reelDocumentPromise.then(function (reelDocument) {
+                    var targetProxy = reelDocument.editingProxyMap.foo;
+                    var listener = targetProxy.listeners[0];
+                    var eventHandler = reelDocument.editingProxyMap.owner;
+
+                    //Perform some edits that will be undoable
+                    reelDocument.updateOwnedObjectEventListener(targetProxy, listener, "press", eventHandler, undefined);
+
+                    //Remove the listener that's been edited, this will be undone shortly
+                    reelDocument.removeOwnedObjectEventListener(targetProxy, listener);
+
+                    return reelDocument.undo().then(function (addedListener) {
+                        //Listener should look as it did before the removal
+                        expect(addedListener.type).toBe("press");
+                        expect(addedListener.listener).toBe(eventHandler);
+                        expect(addedListener.useCapture).toBe(undefined);
+
+                        return reelDocument.undo().then(function (addedListener) {
+                            //Listener should look as it did after undoing both removal and the edit
+                            expect(addedListener.type).toBe("fooEvent");
+                            expect(addedListener.listener).toBe(eventHandler);
+                            expect(addedListener.useCapture).toBe(undefined);
+                        });
+                    });
+
+                }).timeout(WAITSFOR_TIMEOUT);
+            });
+
+            it("should not create a new listener to as a result of undoing edits to a undoing the removal of a listener", function () {
+                return reelDocumentPromise.then(function (reelDocument) {
+                    var targetProxy = reelDocument.editingProxyMap.foo;
+                    var listener = targetProxy.listeners[0];
+                    var expectedListenerCount = targetProxy.listeners.length;
+                    var eventHandler = reelDocument.editingProxyMap.owner;
+
+                    //Perform some edits that will be undoable
+                    reelDocument.updateOwnedObjectEventListener(targetProxy, listener, "press", eventHandler, undefined);
+
+                    //Remove the listener that's been edited, this will be undone shortly
+                    reelDocument.removeOwnedObjectEventListener(targetProxy, listener);
+
+                    return reelDocument.undo().then(function (addedListener) {
+                        expect(targetProxy.listeners.length).toBe(expectedListenerCount);
+                        return reelDocument.undo().then(function (addedListener) {
+                            expect(targetProxy.listeners.length).toBe(expectedListenerCount);
+                        });
+                    });
+
+                }).timeout(WAITSFOR_TIMEOUT);
+            });
+
+        });
+
     });
 
-    describe("defining bindings", function () {
+    describe("defining listeners", function () {
 
         var type, useCapture;
 

--- a/ui/component-editor.reel/component-editor.js
+++ b/ui/component-editor.reel/component-editor.js
@@ -157,11 +157,13 @@ exports.ComponentEditor = Editor.specialize({
     handleAddListenerForObject: {
         value: function (evt) {
             var listenerModel = evt.detail.listenerModel,
+                existingListener = evt.detail.existingListener,
                 listenerJig,
                 overlay;
 
             listenerJig = this.templateObjects.listenerCreator;
             listenerJig.listenerModel = listenerModel;
+            listenerJig.existingListener = existingListener;
 
             overlay = this.templateObjects.eventTargetOverlay;
 //            overlay.anchor = evt.target.element; //TODO when anchoring works well inside this scrollview

--- a/ui/listener-jig.reel/listener-jig.html
+++ b/ui/listener-jig.reel/listener-jig.html
@@ -83,10 +83,10 @@
             }
         },
     
-        "addListenerButton": {
+        "updateEventListenerButton": {
             "prototype": "matte/ui/button.reel",
-            "properties": {"label":"Add Listener",
-                "element": {"#":"addListenerButton"}
+            "properties": {"label":"Define Listener",
+                "element": {"#":"updateEventListenerButton"}
             },
             "listeners": [
                 {
@@ -154,7 +154,7 @@
         
         <footer class="Jig-footer">
             <button data-montage-id="cancelButton" class="Button"></button>
-            <button data-montage-id="addListenerButton" class="Button--action"></button>
+            <button data-montage-id="updateEventListenerButton" class="Button--action"></button>
         </footer>
         
     </div>

--- a/ui/listener-jig.reel/listener-jig.js
+++ b/ui/listener-jig.reel/listener-jig.js
@@ -30,6 +30,10 @@ exports.ListenerJig = Montage.create(Component, /** @lends module:"./listener-ji
         value: true
     },
 
+    existingListener: {
+        value: null
+    },
+
     enterDocument: {
         value: function () {
 
@@ -53,7 +57,7 @@ exports.ListenerJig = Montage.create(Component, /** @lends module:"./listener-ji
         }
     },
 
-    handleAddListenerButtonAction: {
+    handleUpdateEventListenerButtonAction: {
         value: function (evt) {
             evt.stop();
             this._commitListenerEdits();
@@ -78,6 +82,7 @@ exports.ListenerJig = Montage.create(Component, /** @lends module:"./listener-ji
     _discardListenerEdits: {
         value: function () {
             this.listenerModel = null;
+            this.existingListener = null;
             this.dispatchEventNamed("discard", true, false);
         }
     },
@@ -85,19 +90,23 @@ exports.ListenerJig = Montage.create(Component, /** @lends module:"./listener-ji
     _commitListenerEdits: {
         value: function () {
             var model = this.listenerModel,
-                target = model.targetObject,
+                proxy = model.targetObject,
                 type = model.type,
                 listener = model.listener,
                 useCapture = model.useCapture,
                 listenerEntry;
 
-            //TODO provide support for updating an listener entry
-            listenerEntry = this.editingDocument.addOwnedObjectEventListener(target, type, listener, useCapture);
+            if (this.existingListener) {
+                listenerEntry = this.editingDocument.updateOwnedObjectEventListener(proxy, this.existingListener, type, listener, useCapture);
+            } else {
+                listenerEntry = this.editingDocument.addOwnedObjectEventListener(proxy, type, listener, useCapture);
+            }
 
             this.dispatchEventNamed("commit", true, false, {
                 listenerEntry: listenerEntry
             });
 
+            this.existingListener = null;
             this.listenerModel = null;
         }
     },

--- a/ui/template-explorer.reel/content/listener-explorer.reel/listener-entry.reel/listener-entry.html
+++ b/ui/template-explorer.reel/content/listener-explorer.reel/listener-entry.reel/listener-entry.html
@@ -11,6 +11,19 @@
             }
         },
 
+        "pressComposer": {
+            "prototype": "montage/composer/press-composer",
+            "properties": {
+                "component": {"@": "owner"}
+            },
+            "listeners": [
+                {
+                    "type": "press",
+                    "listener": {"@": "owner"}
+                }
+            ]
+        },
+
         "eventType": {
             "prototype": "montage/ui/text.reel",
             "properties": {

--- a/ui/template-explorer.reel/content/listener-explorer.reel/listener-entry.reel/listener-entry.js
+++ b/ui/template-explorer.reel/content/listener-explorer.reel/listener-entry.reel/listener-entry.js
@@ -15,6 +15,26 @@ exports.ListenerEntry = Montage.create(Component, /** @lends module:"./listener-
 
     listenerInfo: {
         value: null
+    },
+
+    targetObject: {
+        value: null
+    },
+
+    handlePress: {
+        value: function(evt) {
+            if (this.listenerInfo) {
+                var listenerModel = Object.create(null);
+                listenerModel.targetObject = this.targetObject;
+                listenerModel.type = this.listenerInfo.type;
+                listenerModel.listener = this.listenerInfo.listener;
+                listenerModel.useCapture = this.listenerInfo.useCapture;
+                this.dispatchEventNamed("editListenerForObject", true, false, {
+                    listenerModel: listenerModel,
+                    existingListener: this.listenerInfo
+                });
+            }
+        }
     }
 
 });

--- a/ui/template-explorer.reel/template-explorer.js
+++ b/ui/template-explorer.reel/template-explorer.js
@@ -77,6 +77,7 @@ exports.TemplateExplorer = Montage.create(Component, /** @lends module:"./templa
             this._element.addEventListener("click", this);
 
             application.addEventListener("editBindingForObject", this, false);
+            application.addEventListener("editListenerForObject", this, false);
 
             this.addRangeAtPathChangeListener("editingDocument.selectedObjects", this, "handleSelectedObjectsChange");
         }
@@ -177,6 +178,18 @@ exports.TemplateExplorer = Montage.create(Component, /** @lends module:"./templa
 
             this.dispatchEventNamed("addListenerForObject", true, false, {
                 listenerModel: listenerModel
+            });
+        }
+    },
+
+    handleEditListenerForObject: {
+        value: function (evt) {
+            var listenerModel = evt.detail.listenerModel;
+            var existingListener = evt.detail.existingListener;
+
+            this.dispatchEventNamed("addListenerForObject", true, false, {
+                listenerModel: listenerModel,
+                existingListener: existingListener
             });
         }
     },


### PR DESCRIPTION
Cliking on a listener brings up the existing listener for editing, with tests for edits and undoability for edits and removal of listeners
