### PR TITLE
Leave listener and binding overlays open...

### DIFF
--- a/ui/binding-jig.reel/binding-jig.js
+++ b/ui/binding-jig.reel/binding-jig.js
@@ -53,6 +53,19 @@ exports.BindingJig = Montage.create(Component, {
         value: null
     },
 
+    shouldDismissOverlay: {
+        value: function (overlay, target) {
+            // don't dismiss the overlay if the user can drag the target
+            while (target) {
+                if (target.draggable) {
+                    return false;
+                }
+                target = target.parentElement;
+            }
+            return true;
+        }
+    },
+
     handleDrop: {
         value: function (event) {
             if (event.dataTransfer.types.has(MimeTypes.SERIALIZATION_OBJECT_LABEL)) {

--- a/ui/component-editor.reel/component-editor.html
+++ b/ui/component-editor.reel/component-editor.html
@@ -106,7 +106,8 @@
             "eventTargetOverlay": {
                 "prototype": "montage/ui/overlay.reel",
                 "properties": {
-                    "element": {"#": "eventTargetOverlay"}
+                    "element": {"#": "eventTargetOverlay"},
+                    "delegate": {"@": "listenerCreator"}
                 }
             },
 
@@ -133,7 +134,8 @@
             "bindingOverlay": {
                 "prototype": "montage/ui/overlay.reel",
                 "properties": {
-                    "element": {"#": "bindingOverlay"}
+                    "element": {"#": "bindingOverlay"},
+                    "delegate": {"@": "bindingCreator"}
                 }
             },
 

--- a/ui/listener-jig.reel/listener-jig.js
+++ b/ui/listener-jig.reel/listener-jig.js
@@ -57,6 +57,19 @@ exports.ListenerJig = Montage.create(Component, /** @lends module:"./listener-ji
         }
     },
 
+    shouldDismissOverlay: {
+        value: function (overlay, target) {
+            // don't dismiss the overlay if the user can drag the target
+            while (target) {
+                if (target.draggable) {
+                    return false;
+                }
+                target = target.parentElement;
+            }
+            return true;
+        }
+    },
+
     handleUpdateEventListenerButtonAction: {
         value: function (evt) {
             evt.stop();


### PR DESCRIPTION
...if the user clicks on an element that can be dragged. This might be a bit too permissive.

Depends on https://github.com/montagejs/montage/pull/1292
