### PR TITLE
Fix highlighting of sub component not present in the dom explorer.

### DIFF
--- a/ui/component-editor.reel/component-editor.js
+++ b/ui/component-editor.reel/component-editor.js
@@ -4,6 +4,7 @@ var Montage = require("montage/core/core").Montage,
     Promise = require("montage/core/promise").Promise,
     WeakMap = require("montage/collections/weak-map"),
     Editor = require("palette/ui/editor.reel").Editor,
+    getElementXPath = require("palette/core/xpath").getElementXPath,
     defaultEventManager = require("montage/core/event/event-manager").defaultEventManager;
 
 exports.ComponentEditor = Editor.specialize({
@@ -231,6 +232,7 @@ exports.ComponentEditor = Editor.specialize({
                 stageElement = detail.element,
                 parentComponents = detail.parentComponents,
                 documentEditor = this.currentDocument,
+                stageDocument = documentEditor._editingController.frame.iframe.contentDocument,
                 domExplorer = this.templateObjects.domExplorer;
 
             // de-highlight all DOM Elements
@@ -249,7 +251,6 @@ exports.ComponentEditor = Editor.specialize({
                     null
                 ).singleNodeValue;
             var nodeProxy = documentEditor.nodeProxyForNode(element);
-
             // handle highlighting at the component level if the DOM element is not found
             if (!nodeProxy && parentComponents) {
                 var parentComponentId;
@@ -261,9 +262,20 @@ exports.ComponentEditor = Editor.specialize({
 
             // select the highlighted domExplorer element
             domExplorer.highlightedDOMElement = nodeProxy;
+
             // highlight the stageElement to simulate a hover
-            documentEditor.clearHighlightedElements();
-            documentEditor.hightlightElement(stageElement);
+            if (nodeProxy.component) {
+                xpath = getElementXPath(nodeProxy._templateNode);
+                element = documentEditor.htmlDocument.evaluate(
+                    xpath,
+                    stageDocument,
+                    null,
+                    XPathResult.FIRST_ORDERED_NODE_TYPE,
+                    null
+                ).singleNodeValue;
+                documentEditor.clearHighlightedElements();
+                documentEditor.hightlightElement(element);
+            }
         }
     },
 


### PR DESCRIPTION
  Prevent the highlight of sub component which are unknown the dom explorer. Instead it will only select the parent component.

At the same time I've added what @mczepiel suggested, we can only highlight component. What can actually be clicked.

![before](https://f.cloud.github.com/assets/1082113/1151082/f3c848da-1ef4-11e3-80b3-b7b6c9eb4e5b.png)
![after](https://f.cloud.github.com/assets/1082113/1151083/f3de60ca-1ef4-11e3-9a27-ea0ee7569f73.png)
