### PR TITLE
exposes converter property of bindings

### DIFF
--- a/core/reel-document.js
+++ b/core/reel-document.js
@@ -1090,8 +1090,8 @@ exports.ReelDocument = EditingDocument.specialize({
     },
 
     defineOwnedObjectBinding: {
-        value: function (proxy, targetPath, oneway, sourcePath, converterObject) {
-            var binding = proxy.defineObjectBinding(targetPath, oneway, sourcePath, converterObject);
+        value: function (proxy, targetPath, oneway, sourcePath, converter) {
+            var binding = proxy.defineObjectBinding(targetPath, oneway, sourcePath, converter);
 
             if (binding) {
                 // if (this._editingController) {
@@ -1152,14 +1152,14 @@ exports.ReelDocument = EditingDocument.specialize({
     },
 
     updateOwnedObjectBinding: {
-        value: function (proxy, existingBinding, targetPath, oneway, sourcePath, converterObject) {
+        value: function (proxy, existingBinding, targetPath, oneway, sourcePath, converter) {
             var originalTargetPath = existingBinding.targetPath,
                 originalOneway = existingBinding.oneway,
                 originalSourcePath = existingBinding.sourcePath,
-                originalconverterObject = existingBinding.converterObject,
+                originalconverter = existingBinding.converter,
                 updatedBinding;
 
-            updatedBinding = proxy.updateObjectBinding(existingBinding, targetPath, oneway, sourcePath, converterObject);
+            updatedBinding = proxy.updateObjectBinding(existingBinding, targetPath, oneway, sourcePath, converter);
 
             if (updatedBinding) {
                 // if (this._editingController) {
@@ -1168,7 +1168,7 @@ exports.ReelDocument = EditingDocument.specialize({
                 // }
 
                 this.undoManager.register("Edit Binding", Promise.resolve([
-                    this.updateOwnedObjectBinding, this, proxy, updatedBinding, originalTargetPath, originalOneway, originalSourcePath, originalconverterObject
+                    this.updateOwnedObjectBinding, this, proxy, updatedBinding, originalTargetPath, originalOneway, originalSourcePath, originalconverter
                 ]));
             }
 

--- a/core/reel-proxy.js
+++ b/core/reel-proxy.js
@@ -176,7 +176,7 @@ var ReelProxy = exports.ReelProxy = EditingProxy.specialize( {
                     bindingDescriptor.targetPath = key;
                     bindingDescriptor.oneway = ("<-" in bindingEntry);
                     bindingDescriptor.sourcePath = bindingDescriptor.oneway ? bindingEntry["<-"] : bindingEntry["<->"];
-                    bindingDescriptor.converterObject =  bindingEntry.converter ? bindingEntry.converter : null;
+                    bindingDescriptor.converter =  bindingEntry.converter ? bindingEntry.converter : null;
 
                     bindings.push(bindingDescriptor);
                 }
@@ -239,14 +239,14 @@ var ReelProxy = exports.ReelProxy = EditingProxy.specialize( {
     },
 
     defineObjectBinding: {
-        value: function (targetPath, oneway, sourcePath, converterObject) {
+        value: function (targetPath, oneway, sourcePath, converter) {
             var binding = Object.create(null);
 
             //TODO guard against binding to the exact same targetPath twice
             binding.targetPath = targetPath;
             binding.oneway = oneway;
             binding.sourcePath = sourcePath;
-            binding.converterObject = converterObject;
+            binding.converter = converter;
 
             this.bindings.push(binding);
 
@@ -264,10 +264,10 @@ var ReelProxy = exports.ReelProxy = EditingProxy.specialize( {
      * @param {string} targetPath The targetPath to set on the binding
      * @param {boolean} oneway Whether or not to set the binding as being oneway
      * @param {string} sourcePath The sourcePath to set on the binding
-     * @param {string} converterObject The converterObject to set on the binding
+     * @param {string} converter The converter to set on the binding
      */
     updateObjectBinding: {
-        value: function (binding, targetPath, oneway, sourcePath, converterObject) {
+        value: function (binding, targetPath, oneway, sourcePath, converter) {
             var existingBinding,
                 bindingIndex = this.bindings.indexOf(binding);
 
@@ -280,7 +280,7 @@ var ReelProxy = exports.ReelProxy = EditingProxy.specialize( {
             binding.targetPath = targetPath;
             binding.oneway = oneway;
             binding.sourcePath = sourcePath;
-            binding.converterObject = converterObject;
+            binding.converter = converter;
 
             return binding;
         }

--- a/core/serialization/reel-visitor.js
+++ b/core/serialization/reel-visitor.js
@@ -82,7 +82,7 @@ exports.ReelVisitor = ProxyVisitor.specialize({
             bindings.forEach(function (binding) {
                 var output = {};
                 var sourcePath = binding.sourcePath;
-                var converterObject = binding.converterObject;
+                var converter = binding.converter;
 
                 if (!binding.oneway) {
                     output["<->"] = sourcePath;
@@ -90,9 +90,9 @@ exports.ReelVisitor = ProxyVisitor.specialize({
                     output["<-"] = sourcePath;
                 }
 
-                if (converterObject) {
+                if (converter) {
                     output.converter = {
-                        "@": converterObject.label
+                        "@": converter.label
                     };
                 }
 

--- a/test/core/reel-document-headless-editing-spec.js
+++ b/test/core/reel-document-headless-editing-spec.js
@@ -50,7 +50,7 @@ describe("core/reel-document-headless-editing-spec", function () {
             "bar": {
                 "prototype": "bar-exportId"
             },
-            "newConverterObject": {
+            "newconverter": {
                 "prototype": "montage/core/converter/converter"
             }
         }, '<div data-montage-id="ownerElement"><div data-montage-id="foo"><span data-montage-id="a"></span><span data-montage-id="b"></span></div></div>');
@@ -433,7 +433,7 @@ describe("core/reel-document-headless-editing-spec", function () {
                     expect(definedBinding.targetPath).toBe(binding.targetPath);
                     expect(definedBinding.oneway).toBe(binding.oneway);
                     expect(definedBinding.sourcePath).toBe(binding.sourcePath);
-                    expect(definedBinding.converterObject).toBe(binding.converterObject);
+                    expect(definedBinding.converter).toBe(binding.converter);
                 });
 
             }).timeout(WAITSFOR_TIMEOUT);
@@ -462,10 +462,10 @@ describe("core/reel-document-headless-editing-spec", function () {
                 return reelDocumentPromise.then(function (reelDocument) {
                     var targetProxy = reelDocument.editingProxyMap.foo;
                     var binding = targetProxy.bindings[0];
-                    var newConverterObject = reelDocument.editingProxyMap.newConverterObject;
+                    var newconverter = reelDocument.editingProxyMap.newconverter;
 
                     //Perform some edits that will be undoable
-                    reelDocument.updateOwnedObjectBinding(targetProxy, binding, "newTargetPath", false, "newSourcePath", newConverterObject);
+                    reelDocument.updateOwnedObjectBinding(targetProxy, binding, "newTargetPath", false, "newSourcePath", newconverter);
 
                     //Remove the binding that's been edited, this will be undone shortly
                     reelDocument.cancelOwnedObjectBinding(targetProxy, binding);
@@ -475,14 +475,14 @@ describe("core/reel-document-headless-editing-spec", function () {
                         expect(definedBinding.targetPath).toBe("newTargetPath");
                         expect(definedBinding.oneway).toBe(false);
                         expect(definedBinding.sourcePath).toBe("newSourcePath");
-                        expect(definedBinding.converterObject).toBe(newConverterObject);
+                        expect(definedBinding.converter).toBe(newconverter);
 
                         return reelDocument.undo().then(function (definedBinding) {
                             //Binding should look as it did after undoing both removal and the edit
                             expect(definedBinding.targetPath).toBe("targetValue");
                             expect(definedBinding.oneway).toBe(true);
                             expect(definedBinding.sourcePath).toBe("@bar.sourceValue");
-                            expect(definedBinding.converterObject).toBe(null);
+                            expect(definedBinding.converter).toBe(null);
                         });
                     });
 
@@ -494,10 +494,10 @@ describe("core/reel-document-headless-editing-spec", function () {
                     var targetProxy = reelDocument.editingProxyMap.foo;
                     var binding = targetProxy.bindings[0];
                     var expectedBindingCount = targetProxy.bindings.length;
-                    var newConverterObject = reelDocument.editingProxyMap.newConverterObject;
+                    var newconverter = reelDocument.editingProxyMap.newconverter;
 
                     //Perform some edits that will be undoable
-                    reelDocument.updateOwnedObjectBinding(targetProxy, binding, "newTargetPath", false, "newSourcePath", "newConverterObject");
+                    reelDocument.updateOwnedObjectBinding(targetProxy, binding, "newTargetPath", false, "newSourcePath", "newconverter");
 
                     //Remove the binding that's been edited, this will be undone shortly
                     reelDocument.cancelOwnedObjectBinding(targetProxy, binding);
@@ -518,25 +518,25 @@ describe("core/reel-document-headless-editing-spec", function () {
 
     describe("defining bindings", function () {
 
-        var targetPath, oneway, sourcePath, converterObject;
+        var targetPath, oneway, sourcePath, converter;
 
         beforeEach(function () {
             targetPath = "a.Target.Path";
             oneway = true;
             sourcePath = "a.Source.Path";
-            converterObject = "";
+            converter = "";
         });
 
         it ("should define the binding with the expected properties", function () {
             return reelDocumentPromise.then(function (reelDocument) {
                 var targetProxy = reelDocument.editingProxyMap.foo;
 
-                var binding = reelDocument.defineOwnedObjectBinding(targetProxy, targetPath, oneway, sourcePath, converterObject);
+                var binding = reelDocument.defineOwnedObjectBinding(targetProxy, targetPath, oneway, sourcePath, converter);
 
                 expect(binding.targetPath).toBe(targetPath);
                 expect(binding.oneway).toBe(oneway);
                 expect(binding.sourcePath).toBe(sourcePath);
-                expect(binding.converterObject).toBe(converterObject);
+                expect(binding.converter).toBe(converter);
 
             }).timeout(WAITSFOR_TIMEOUT);
         });
@@ -544,7 +544,7 @@ describe("core/reel-document-headless-editing-spec", function () {
         it ("should define the binding on the specified object", function () {
             return reelDocumentPromise.then(function (reelDocument) {
                 var targetProxy = reelDocument.editingProxyMap.foo;
-                var binding = reelDocument.defineOwnedObjectBinding(targetProxy, targetPath, oneway, sourcePath, converterObject);
+                var binding = reelDocument.defineOwnedObjectBinding(targetProxy, targetPath, oneway, sourcePath, converter);
 
                 expect(targetProxy.bindings.indexOf(binding) === -1).toBeFalsy();
 
@@ -555,7 +555,7 @@ describe("core/reel-document-headless-editing-spec", function () {
         it ("should register an undoable operation for the defining of a binding", function () {
             return reelDocumentPromise.then(function (reelDocument) {
                 var targetProxy = reelDocument.editingProxyMap.foo;
-                var binding = reelDocument.defineOwnedObjectBinding(targetProxy, targetPath, oneway, sourcePath, converterObject);
+                var binding = reelDocument.defineOwnedObjectBinding(targetProxy, targetPath, oneway, sourcePath, converter);
 
                 expect(reelDocument.undoManager.undoCount).toBe(1);
 
@@ -565,7 +565,7 @@ describe("core/reel-document-headless-editing-spec", function () {
         it ("should undo the defining of a binding by removing that binding", function () {
             return reelDocumentPromise.then(function (reelDocument) {
                 var targetProxy = reelDocument.editingProxyMap.foo;
-                var binding = reelDocument.defineOwnedObjectBinding(targetProxy, targetPath, oneway, sourcePath, converterObject);
+                var binding = reelDocument.defineOwnedObjectBinding(targetProxy, targetPath, oneway, sourcePath, converter);
 
                 return reelDocument.undo().then(function (deletedBinding) {
                     expect(deletedBinding).toBe(binding);

--- a/ui/binding-jig.reel/binding-jig.html
+++ b/ui/binding-jig.reel/binding-jig.html
@@ -76,13 +76,13 @@
             }
         },
 
-        "converterObject": {
+        "converter": {
             "prototype": "matte/ui/input-text.reel",
             "properties": {
-                "element": {"#": "converterObject"}
+                "element": {"#": "converter"}
             },
             "bindings": {
-                "value": {"<->": "@owner.bindingModel.converterObject", "converter": {"@": "objectLabelConverter"}}
+                "value": {"<->": "@owner.bindingModel.converter", "converter": {"@": "objectLabelConverter"}}
             }
         },
 
@@ -165,7 +165,7 @@
 
         <section class="Jig-section BindingJig-section--source">
             <label class="Jig-label">Converter (Optional)</label>
-            <input data-montage-id="converterObject" class="Jig-input" type="text">
+            <input data-montage-id="converter" class="Jig-input" type="text">
         </section>
 
         <footer class="Jig-footer">

--- a/ui/binding-jig.reel/binding-jig.js
+++ b/ui/binding-jig.reel/binding-jig.js
@@ -128,13 +128,13 @@ exports.BindingJig = Montage.create(Component, {
                 targetPath = model.targetPath,
                 oneway = model.oneway,
                 sourcePath = model.sourcePath,
-                converterObject = model.converterObject,
+                converter = model.converter,
                 bindingEntry;
 
             if (this.existingBinding) {
-                bindingEntry = this.editingDocument.updateOwnedObjectBinding(proxy, this.existingBinding, targetPath, oneway, sourcePath, converterObject);
+                bindingEntry = this.editingDocument.updateOwnedObjectBinding(proxy, this.existingBinding, targetPath, oneway, sourcePath, converter);
             } else {
-                bindingEntry = this.editingDocument.defineOwnedObjectBinding(proxy, targetPath, oneway, sourcePath, converterObject);
+                bindingEntry = this.editingDocument.defineOwnedObjectBinding(proxy, targetPath, oneway, sourcePath, converter);
             }
 
 

--- a/ui/template-explorer.reel/content/binding-explorer.reel/binding-entry.reel/binding-entry.js
+++ b/ui/template-explorer.reel/content/binding-explorer.reel/binding-entry.reel/binding-entry.js
@@ -30,7 +30,7 @@ exports.BindingEntry = Montage.create(Component, /** @lends module:"./binding-en
                 bindingModel.targetPath = this.binding.targetPath;
                 bindingModel.oneway = this.binding.oneway;
                 bindingModel.sourcePath = this.binding.sourcePath;
-                bindingModel.converterObject = this.binding.converterObject;
+                bindingModel.converter = this.binding.converter;
 
                 this.dispatchEventNamed("editBindingForObject", true, false, {
                     bindingModel: bindingModel,


### PR DESCRIPTION
- makes it possible to add and edit existing converters on bindings 
- deserializes and serializes binding converters if they were specified 
- doesnt serialize converters if they are empty
