### PR TITLE
prevent adding a component to itself

### DIFF
--- a/ui/component-editor.reel/component-editor.html
+++ b/ui/component-editor.reel/component-editor.html
@@ -32,7 +32,8 @@
                     "element": {"#": "library"}
                 },
                 "bindings": {
-                    "groups": {"<->": "@owner.projectController.libraryGroups"}
+                    "groups": {"<->": "@owner.projectController.libraryGroups"},
+                    "editingComponentPrototype": {"<-": "@owner.projectController.currentDocument._moduleId"}
                 },
                 "listeners": [
                     {

--- a/ui/library.reel/library-cell.reel/library-cell.css
+++ b/ui/library.reel/library-cell.reel/library-cell.css
@@ -32,7 +32,10 @@
     border-radius: 0 0 4px 4px;
 }
 
-
+.LibraryCell-button[draggable=false] {
+    background-color: hsl(43, 100%, 85%) !important;
+    opacity: .5 !important;
+}
 
 /* Icon --------------------------------- */
 

--- a/ui/library.reel/library-cell.reel/library-cell.html
+++ b/ui/library.reel/library-cell.reel/library-cell.html
@@ -38,6 +38,9 @@
                 "element": {"#": "add-button"},
                 "identifier": "prototypeButton"
             },
+            "bindings": {
+                "draggable": {"<-": "@owner.editingComponentPrototype != @owner.prototypeObject.serialization.prototype"}
+            },
             "listeners": [
                 {
                     "type": "action",
@@ -50,7 +53,7 @@
 </head>
 <body>
     <li data-montage-id="library-cell" class="LibraryCell">
-        <button data-montage-id="add-button" class="LibraryCell-button" draggable="true">
+        <button data-montage-id="add-button" class="LibraryCell-button">
             <img data-montage-id="prototype-icon" class="LibraryCell-button-icon" draggable="false" src="../../../assets/img/library-icon.png">
             <span data-montage-id="prototype-name" class="LibraryCell-button-label"></span>
         </button>

--- a/ui/library.reel/library-group.reel/library-group.html
+++ b/ui/library.reel/library-group.reel/library-group.html
@@ -58,7 +58,8 @@
                 "element": {"#": "libraryItemCell"}
             },
             "bindings": {
-                "prototypeObject": {"<-": "@libraryItemList.objectAtCurrentIteration"}
+                "prototypeObject": {"<-": "@libraryItemList.objectAtCurrentIteration"},
+                "editingComponentPrototype": {"<-": "@owner.editingComponentPrototype"}
             }
         }
     }

--- a/ui/library.reel/library.html
+++ b/ui/library.reel/library.html
@@ -39,6 +39,7 @@
                 },
                 "bindings": {
                     "details": {"<-": "@groupList.objectAtCurrentIteration"},
+                    "editingComponentPrototype": {"<-": "@owner.editingComponentPrototype"},
                     "filterPath": {"<-": "@owner.filterPath"}
                 }
             },


### PR DESCRIPTION
currently if a component is added to itself it crashes filament.

this prevents dragging a component to itself, by making the component non-draggable and communicating that is different from other components in the library by using the owner colours and half opacity.

Note: doesn't prevent transitive recursion...that still crashes filament...

![screen shot 2013-10-16 at 8 35 18 pm](https://f.cloud.github.com/assets/196199/1352916/cd6221a0-373d-11e3-8ae1-01e6a344c928.png)
