### PR TITLE
Fix an issue when Dragging a dependency over a list.

### DIFF
--- a/extensions/package-manager.filament-extension/ui/package-dependencies.reel/package-dependencies-groups.reel/package-dependencies-group.reel/package-dependencies-group.css
+++ b/extensions/package-manager.filament-extension/ui/package-dependencies.reel/package-dependencies-groups.reel/package-dependencies-group.reel/package-dependencies-group.css
@@ -18,3 +18,7 @@
     padding: 0;
     list-style: none;
 }
+
+.element-disablePointerEvents {
+    pointer-events: none;
+}

--- a/extensions/package-manager.filament-extension/ui/package-dependencies.reel/package-dependencies-groups.reel/package-dependencies-group.reel/package-dependencies-group.html
+++ b/extensions/package-manager.filament-extension/ui/package-dependencies.reel/package-dependencies-groups.reel/package-dependencies-group.reel/package-dependencies-group.html
@@ -23,7 +23,8 @@
                 "element": {"#": "packageDependenciesGroupTitle"}
             },
             "bindings": {
-                "value": {"<-": "@owner.title"}
+                "value": {"<-": "@owner.title"},
+                "classList.has('element-disablePointerEvents')" : { "<-" : "@owner._willAcceptDrop"}
             }
         },
 
@@ -43,6 +44,9 @@
                 "element": {"#": "dependenciesList"},
                 "isSelectionEnabled": true,
                 "contentController": {"@": "dependencyContentController"}
+            },
+            "bindings": {
+                "classList.has('element-disablePointerEvents')" : { "<-" : "@owner._willAcceptDrop"}
             }
          },
 

--- a/extensions/package-manager.filament-extension/ui/package-dependencies.reel/package-dependencies-groups.reel/package-dependencies-group.reel/package-dependencies-group.js
+++ b/extensions/package-manager.filament-extension/ui/package-dependencies.reel/package-dependencies-groups.reel/package-dependencies-group.reel/package-dependencies-group.js
@@ -77,20 +77,24 @@ exports.PackageDependenciesGroup = Component.specialize(/** @lends PackageDepend
 
     handleDragover: {
         value: function (event) {
-            var dataTransfer = event.dataTransfer,
+            if (!this._willAcceptDrop) {
+                var dataTransfer = event.dataTransfer,
                 availableTypes = dataTransfer.types;
 
-            if (availableTypes) {
-                if (availableTypes.has(MIME_TYPES.PACKAGE_MANAGER_SERIALIZATION_DEPENDENCY) ||
-                    availableTypes.has(MIME_TYPES.PACKAGE_MANAGER_INSTALLATION_DEPENDENCY)) {
+                if (availableTypes) {
+                    if (availableTypes.has(MIME_TYPES.PACKAGE_MANAGER_SERIALIZATION_DEPENDENCY) ||
+                        availableTypes.has(MIME_TYPES.PACKAGE_MANAGER_INSTALLATION_DEPENDENCY)) {
 
-                    event.preventDefault();
-                    dataTransfer.dropEffect = dataTransfer.effectAllowed;
-                    this._willAcceptDrop = true;
+                        event.preventDefault();
+                        dataTransfer.dropEffect = dataTransfer.effectAllowed;
+                        this._willAcceptDrop = true;
+                    }
+                } else {
+                    dataTransfer.dropEffect = "none";
+                    this._willAcceptDrop = false;
                 }
-            } else {
-                dataTransfer.dropEffect = "none";
-                this._willAcceptDrop = false;
+            } else { // Already accept Drop
+                event.preventDefault();
             }
         }
     },


### PR DESCRIPTION
Block each child elements of a DependencyCell to raise the `dragleave` event. In order to avoid that the property `_willAcceptDrop` to be set to false and then to change the DependencyList classList.
