### PR TITLE
Fix DnD with Palette and the latest CEF, let's be friend with Plume again! 

### DIFF
--- a/ui/dom-explorer.reel/create-node-cell.reel/create-node-cell.js
+++ b/ui/dom-explorer.reel/create-node-cell.reel/create-node-cell.js
@@ -89,7 +89,7 @@ exports.CreateNodeCell = Component.specialize(/** @lends CreateNodeCell# */ {
         value: function (evt) {
             if (!this.tagName) {return;}
 
-            evt.dataTransfer.effectAllowed = "all";
+            evt.dataTransfer.effectAllowed = "copyMove";
             var element = document.createElement(this.tagName);
             if (this.montageArg){
                 element.dataset.arg = this.montageArg;

--- a/ui/dom-explorer.reel/node-cell.reel/node-cell.js
+++ b/ui/dom-explorer.reel/node-cell.reel/node-cell.js
@@ -77,7 +77,7 @@ exports.NodeCell = Montage.create(Component, /** @lends module:"./node-cell.reel
 
     handleDragstart: {
         value: function (event) {
-            event.dataTransfer.effectAllowed = 'all';
+            event.dataTransfer.effectAllowed = "copyMove";
 
             var nodeInfo = this.nodeInfo;
 

--- a/ui/library.reel/library-cell.reel/library-cell.js
+++ b/ui/library.reel/library-cell.reel/library-cell.js
@@ -32,7 +32,7 @@ exports.LibraryCell = Montage.create(Component, /** @lends module:"ui/library-ce
 
     captureDragstart: {
         value: function (event) {
-            event.dataTransfer.effectAllowed = 'all';
+            event.dataTransfer.effectAllowed = "copyMove";
 
             // Although we could use "application/json" here, the stage is
             // expecting a specific object type. We also might specially handle

--- a/ui/template-explorer.reel/content/binding-explorer.reel/binding-entry.reel/binding-entry.js
+++ b/ui/template-explorer.reel/content/binding-explorer.reel/binding-entry.reel/binding-entry.js
@@ -50,7 +50,7 @@ exports.BindingEntry = Montage.create(Component, /** @lends module:"./binding-en
 
     handleDragstart: {
         value: function (event) {
-            event.dataTransfer.effectAllowed = 'all';
+            event.dataTransfer.effectAllowed = "copyMove";
 
             if (this.targetObject && this.binding) {
                 var bindingModel = Object.create(null);

--- a/ui/template-explorer.reel/content/binding-explorer.reel/binding-explorer.js
+++ b/ui/template-explorer.reel/content/binding-explorer.reel/binding-explorer.js
@@ -61,8 +61,7 @@ exports.BindingExplorer = Component.specialize( /** @lends BindingsExplorer# */ 
                 if (this.acceptsBindingCopy(event)) {
                     event.dataTransfer.dropEffect = "copy";
                 } else {
-                    // event.dataTransfer.dropEffect = "move";
-                    event.dataTransfer.dropEffect = "link";
+                    event.dataTransfer.dropEffect = "move";
                 }
             } else {
                 event.dataTransfer.dropEffect = "none";

--- a/ui/template-explorer.reel/content/element-field.reel/element-field.js
+++ b/ui/template-explorer.reel/content/element-field.reel/element-field.js
@@ -45,7 +45,7 @@ exports.ElementField = Component.specialize(/** @lends ElementField# */ {
                 // allows us to drop
                 event.preventDefault();
                 event.stopPropagation();
-                event.dataTransfer.dropEffect = "link";
+                event.dataTransfer.dropEffect = "copy";
                 this._willAcceptDrop = true;
             }
         }

--- a/ui/template-explorer.reel/content/listener-explorer.reel/listener-entry.reel/listener-entry.js
+++ b/ui/template-explorer.reel/content/listener-explorer.reel/listener-entry.reel/listener-entry.js
@@ -58,7 +58,7 @@ exports.ListenerEntry = Montage.create(Component, /** @lends module:"./listener-
 
     handleDragstart: {
         value: function (event) {
-            event.dataTransfer.effectAllowed = 'all';
+            event.dataTransfer.effectAllowed = "copyMove";
             var listenerModel = Object.create(null),
                 listener = this.listenerInfo.listener;
 

--- a/ui/template-explorer.reel/content/listener-explorer.reel/listener-explorer.js
+++ b/ui/template-explorer.reel/content/listener-explorer.reel/listener-explorer.js
@@ -88,11 +88,10 @@ exports.ListenerExplorer = Component.specialize(/** @lends ListenerExplorer# */ 
                 if (this.acceptsListenerCopy(event)) {
                     event.dataTransfer.dropEffect = "copy";
                 } else {
-                    // event.dataTransfer.dropEffect = "move";
-                    event.dataTransfer.dropEffect = "link";
+                    event.dataTransfer.dropEffect = "copy";
                 }
             } else {
-                event.dataTransfer.dropEffect = "link";
+                event.dataTransfer.dropEffect = "copy";
             }
         }
     },
@@ -168,7 +167,7 @@ exports.ListenerExplorer = Component.specialize(/** @lends ListenerExplorer# */ 
                 transfer = event.dataTransfer;
 
             if (target === listenerButtonElement) {
-                transfer.effectAllowed = 'all';
+                transfer.effectAllowed = "copyMove";
 
                 var eventType = "action"; //TODO allow this to be inferred from somewhere
                 var transferObject = {

--- a/ui/template-explorer.reel/owner-object-cell.reel/owner-object-cell.js
+++ b/ui/template-explorer.reel/owner-object-cell.reel/owner-object-cell.js
@@ -75,7 +75,7 @@ exports.OwnerObjectCell = Component.specialize({
                 // allows us to drop
                 event.preventDefault();
                 event.stopPropagation();
-                event.dataTransfer.dropEffect = "link";
+                event.dataTransfer.dropEffect = "copy";
                 this._willAcceptDrop = true;
             }
         }

--- a/ui/template-explorer.reel/template-object-cell.reel/template-object-cell.js
+++ b/ui/template-explorer.reel/template-object-cell.reel/template-object-cell.js
@@ -107,7 +107,7 @@ exports.TemplateObjectCell = Component.specialize({
                 // allows us to drop
                 event.preventDefault();
                 event.stopPropagation();
-                event.dataTransfer.dropEffect = "link";
+                event.dataTransfer.dropEffect = "copy";
                 this._willAcceptDrop = true;
             }
         }


### PR DESCRIPTION
This is more of a workarround than a fix.
After doing some testing it seems that any effect of type 'link' must be
avoid. This affects both 'effectAllowed' and 'dropEffect'.

'effectAllowed' can be any of the following:
- copy
- move
- copyMove
- none

'dropEffect' must be any of the following:
- copy
- move
