### PR TITLE
Fix an issue with the packageExplorer when a file is removed.

### DIFF
--- a/core/project-controller.js
+++ b/core/project-controller.js
@@ -1056,7 +1056,9 @@ exports.ProjectController = ProjectController = DocumentController.specialize({
                 parent = this.fileInTreeAtUrl(parentUrl),
                 child = this.fileInTreeAtUrl(fileUrl);
 
-            parent.children.delete(child);
+            if (parent && parent.expanded) {
+                parent.children.delete(child);
+            }
 
             //TODO try to be more focused about this based upon the file that was deleted
             this.populateLibrary().done();


### PR DESCRIPTION
If we remove a file from /project/assets/images/, I will got the following error:
"TypeError: Cannot read property 'children' of null"

But I don't have this error when I expand the Tree until the folder images, so I assume that the tree is build "on-the-fly".

So,I added an condition and I don't have the error anymore. 
