### PR TITLE
Guard against menu actions for the current document

### DIFF
--- a/extensions/code-editor.filament-extension/core/code-editor-document.js
+++ b/extensions/code-editor.filament-extension/core/code-editor-document.js
@@ -118,6 +118,10 @@ var CodeEditorDocument = exports.CodeEditorDocument = Document.specialize({
         value: function (evt) {
             var identifier = evt.detail.identifier;
 
+            if (this.editor.currentDocument !== this) {
+                return;
+            }
+
             if ("undo" === identifier) {
                 if (this.canUndo) {
                     this.undo().done();


### PR DESCRIPTION
When a menu action is fired make sure the CodeEditorDocument instance is the current document before applying changes.
