### PR TITLE
Fix crash on component creation cancel

### DIFF
--- a/core/project-controller.js
+++ b/core/project-controller.js
@@ -936,7 +936,11 @@ exports.ProjectController = ProjectController = DocumentController.specialize({
             var self = this;
             return this._create("component", "ui",
                 this.environmentBridge.createComponent.bind(this.environmentBridge)).then(function (componentUrl) {
-                    return self.openUrlForEditing(componentUrl).thenResolve(componentUrl);
+                    if (componentUrl) {
+                        return self.openUrlForEditing(componentUrl).thenResolve(componentUrl);
+                    } else {
+                        return Promise.resolve(null);
+                    }
                 });
         }
     },


### PR DESCRIPTION
It was due to giving null to openUrlForEditing which is not null proof.
