### PR TITLE
Hide the show hidden cards switch when needed

### DIFF
--- a/ui/template-explorer.reel/template-explorer.css
+++ b/ui/template-explorer.reel/template-explorer.css
@@ -80,10 +80,6 @@
     background: url(/assets/icons/eye.png) no-repeat center;
     background-size: auto 14px;
 }
-.TemplateExplorer-filterToggle--eye.matte-InputCheckbox.disabled,
-.TemplateExplorer-header-counter.disabled {
-    display: none;
-}
 
 .TemplateExplorer-filterToggle.matte-InputCheckbox:hover {
     background-color: hsl(0,0%,100%);

--- a/ui/template-explorer.reel/template-explorer.html
+++ b/ui/template-explorer.reel/template-explorer.html
@@ -12,7 +12,8 @@
             },
             "bindings": {
                 "classList.has('Filament--willAcceptDrop')": {"<-": "@owner._willAcceptDrop"},
-                "templateObjectFilterTerm": {"<->": "editingDocument.sideData.templateObjectFilterTerm"}
+                "templateObjectFilterTerm": {"<->": "editingDocument.sideData.templateObjectFilterTerm"},
+                "hiddenCardsCount": {"<-": "@owner.templateObjectsController.content.filter{!!editorMetadata.get('isHidden')}.length"}
             },
             "listeners": [
                 {
@@ -28,8 +29,7 @@
                 "value": "Text"
             },
             "bindings": {
-                "value": {"<-": "@owner.templateObjectsController.content.filter{!!editorMetadata.get('isHidden')}.length"},
-                "classList.has('disabled')": {"<-": "@owner.templateObjectsController.content.filter{!!editorMetadata.get('isHidden')}.length == 0"}
+                "value": {"<-": "@owner.hiddenCardsCount"}
             }
         },
         "objectList": {
@@ -69,8 +69,7 @@
                 "element": {"#": "showHidden"}
             },
             "bindings": {
-                "checked": {"<->": "@owner.showHidden"},
-                "classList.has('disabled')": {"<-": "@owner.templateObjectsController.content.filter{!!editorMetadata.get('isHidden')}.length == 0"}
+                "checked": {"<->": "@owner.showHidden"}
             }
         },
         "showListeners": {

--- a/ui/template-explorer.reel/template-explorer.js
+++ b/ui/template-explorer.reel/template-explorer.js
@@ -19,6 +19,23 @@ exports.TemplateExplorer = Montage.create(Component, /** @lends module:"./templa
         value: false
     },
 
+    _hiddenCardsCount: {
+        value: 0
+    },
+
+    hiddenCardsCount: {
+        get: function () {
+            return this._hiddenCardsCount;
+        },
+        set: function (value) {
+            if (value === this._hiddenCardsCount) {
+                return;
+            }
+            this._hiddenCardsCount = value;
+            this.needsDraw = true;
+        }
+    },
+
     showHidden: {
         get: function () {
             return this._hidden;
@@ -302,6 +319,8 @@ exports.TemplateExplorer = Montage.create(Component, /** @lends module:"./templa
                     this.needsDraw = true;
                 }
             }
+            var label = this.element.querySelector(".TemplateExplorer-hiddenControl");
+            label.classList.toggle("is-hidden", this.hiddenCardsCount === 0);
         }
     }
 


### PR DESCRIPTION
It is hidden rather than disabled, because the matte/checkbox does not support disabling :disappointed:
