### PR TITLE
Make tab the same background color is the editor

### DIFF
--- a/ui/document-tab.reel/document-tab.css
+++ b/ui/document-tab.reel/document-tab.css
@@ -128,3 +128,8 @@
 .DocumentTab.document-dirty .DocumentTab-close:hover:before {
     content: "×";
 }
+
+
+.DocumentTab.selected.document-solarized-light {
+	background-color: hsl(44, 87%, 96%);
+}

--- a/ui/document-tab.reel/document-tab.html
+++ b/ui/document-tab.reel/document-tab.html
@@ -11,7 +11,8 @@
             },
             "bindings": {
                 "classList.has('document-dirty')" : { "<-" : "@owner.document.isDirty"},
-                "classList.has('document-error')": {"<-": "!!@owner.document.errors.length"}
+                "classList.has('document-error')": {"<-": "!!@owner.document.errors.length"},
+                "classList.has('document-solarized-light')": {"<-": "@owner.document.editor.theme=='solarized light'"}
             }
         },
 


### PR DESCRIPTION
![screen shot 2014-01-13 at 11 43 52 am](https://f.cloud.github.com/assets/55838/1904135/928406aa-7c8b-11e3-86f3-10f2b3f0e39d.png)

@simurai there is still a gradient under the tab It’s defined on CodeEditor, not tabs. Not sure what to do about it.
