### PR TITLE
Add montage event to close dopzones on failled drop

### DIFF
--- a/ui/component-editor.reel/component-editor.js
+++ b/ui/component-editor.reel/component-editor.js
@@ -92,6 +92,8 @@ exports.ComponentEditor = Editor.specialize({
                 this.addEventListener("highlightComponent", this, false);
                 // deHighlight everywhere
                 this.addEventListener("deHighlight", this, false);
+                // Library item dragend
+                this.addEventListener("templateObjectDragend", this, false);
             }
         }
     },
@@ -385,6 +387,13 @@ exports.ComponentEditor = Editor.specialize({
             if (stageElement) {
                 documentEditor.highlightElement(stageElement);
             }
+        }
+    },
+
+    handleTemplateObjectDragend: {
+        value: function (evt) {
+            var domExplorer = this.templateObjects.domExplorer;
+            domExplorer.addElementNodeHover = null;
         }
     }
 

--- a/ui/library.reel/library-cell.reel/library-cell.js
+++ b/ui/library.reel/library-cell.reel/library-cell.js
@@ -18,6 +18,7 @@ exports.LibraryCell = Montage.create(Component, /** @lends module:"ui/library-ce
         value: function (firstTime) {
             if (firstTime) {
                 this._element.addEventListener("dragstart", this, true);
+                this._element.addEventListener("dragend", this, false);
             }
         }
     },
@@ -53,6 +54,12 @@ exports.LibraryCell = Montage.create(Component, /** @lends module:"ui/library-ce
                 iconElement.width / 2,
                 iconElement.height / 2
             );
+        }
+    },
+
+    handleDragend: {
+        value: function (evt) {
+            this.dispatchEventNamed("templateObjectDragend", true);
         }
     },
 


### PR DESCRIPTION
The dragend event is dispatch on the source no the hovered elements.
And we need it as closing drop zone on leave is not an option (gets you into infinite loops of UI hell)
This PR adds a _montage event_ to by-pass this limitation
