### PR TITLE
Fix: in Lumieres "Add Component..." directory selection dialog doesn't select the "ui" folder by default

### DIFF
--- a/core/project-controller.js
+++ b/core/project-controller.js
@@ -194,6 +194,10 @@ exports.ProjectController = ProjectController = DocumentController.specialize({
         value: function (packageUrl, dependencies) {
             var self = this;
 
+            if (packageUrl[packageUrl.length - 1] !== '/') {
+                packageUrl += '/';
+            }
+
             this.dispatchEventNamed("willOpenPackage", true, false, {
                 packageUrl: packageUrl
             });


### PR DESCRIPTION
Add a slash since packageUrl is always a directory.

``` js
URL.resolve("a/b",  "c") // "a/c"
URL.resolve("a/b/", "c") // "a/b/c"
```
