### PR TITLE
Prevent every property change to rebuilt the template tree

### DIFF
--- a/core/reel-document.js
+++ b/core/reel-document.js
@@ -523,7 +523,9 @@ exports.ReelDocument = EditingDocument.specialize({
     setOwnedObjectProperty: {
         value: function (proxy, property, value){
             this.super(proxy, property, value);
-            this.buildTemplateObjectTree();
+            if (property === "element") {
+                this.buildTemplateObjectTree();
+            }
         }
     },
 


### PR DESCRIPTION
Only the property element require a tree rebuild.
