### PR TITLE
Fix package explorer expansion acting up

### DIFF
--- a/ui/package-explorer.reel/file-cell.reel/file-cell.js
+++ b/ui/package-explorer.reel/file-cell.reel/file-cell.js
@@ -43,7 +43,7 @@ exports.FileCell = Montage.create(Component, {
 
     handleExpandedChange: {
         value: function(newValue) {
-            if (newValue && !this.fileInfo.expanded) {
+            if (newValue && this.fileInfo && !this.fileInfo.expanded) {
                 var self = this;
                 this.projectController.filesAtUrl(this.fileInfo.fileUrl).then(function (fileDescriptors) {
                     self.fileInfo.expanded = true;


### PR DESCRIPTION
This fixes both file being added twice and expansion failing.
The binding setting the expanded property is called before the one
setting the fileInfo property on which we rely if expanded == true.
The use case when actually need to make a call when expanded is set to
true only happen if fileInfo is already set, which happen when the user
click on the checkbox and toggle the expanded value.
I supposed the problem here comes from rely on a bound property to act
on a user input. The situation would be less ambiguous if we were
expanding only on checkbox action since a binding change is fired when
the an already load but hidden cell is redrawn.
