### PR TITLE
Don't fail when requested to close same file twice

### DIFF
--- a/test/core/project-controller-file-spec.js
+++ b/test/core/project-controller-file-spec.js
@@ -249,6 +249,28 @@ describe("core/project-controller-file-spec", function () {
                 });
             });
 
+            describe("that is in the process of being closed", function () {
+
+                it("must return a promise for document being closed", function () {
+                    var firstClosePromise =  projectController.closeDocument(openedDocument);
+                    var secondClosePromise = projectController.closeDocument(openedDocument);
+                    expect(secondClosePromise).toBe(firstClosePromise);
+                    firstClosePromise.done();
+                    secondClosePromise.done();
+                });
+
+                it("must return a promise for document being closed", function () {
+                    return Promise.all([
+                        projectController.closeDocument(openedDocument),
+                        projectController.closeDocument(openedDocument)
+                    ]).spread(function (firstDocument, secondDocument) {
+                        expect(secondDocument).toBe(openedDocument);
+                        expect(secondDocument).toBe(firstDocument);
+                    });
+                });
+
+            });
+
         });
 
     });


### PR DESCRIPTION
While it generally shouldn't happen, there's no reason for errors
downstream if we end up being requested to close a file we're in the
process of closing.

Now we simply return the same promise for the file we're closing.

This was happening due to multiple listeners observing the close
key command in the Lumieres environment. I'll have a fix for that but
didn't want to lose the chance to fix a good bug worth safeguarding
against.
