### PR TITLE
Fix the logic to display a message when the list of projects is empty (FLY-54)

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -136,8 +136,15 @@
         ]
     },
     "recent_projects": {
-        "message": "Recent Projects",
+        "message": "Projects",
         "description": "Title for the projects the user has most recently worked on",
+        "locations": [
+            "welcome/ui/main.reel/main.html"
+        ]
+    },
+    "empty_projects": {
+        "message": "No Montage projects found",
+        "description": "Text to show to the user when there is no Montage project available",
         "locations": [
             "welcome/ui/main.reel/main.html"
         ]

--- a/project-list/ui/main.reel/main.css
+++ b/project-list/ui/main.reel/main.css
@@ -265,6 +265,13 @@
     background-color: hsl(0,0%,96%);
 }
 
+.History-empty {
+    margin-top: 1em;
+    color: hsl(0, 0%, 70%);
+    text-align: center;
+    font-size: 14px;
+}
+
 .History-list {
     position: relative;
     margin: 0;

--- a/project-list/ui/main.reel/main.html
+++ b/project-list/ui/main.reel/main.html
@@ -17,6 +17,10 @@
                 "properties": {
                     "element": {"#": "main"}
                 },
+                "bindings": {
+                    "projects.Recent": {"<-": "@repositoriesController.recentRepositoriesContent.organizedContent"},
+                    "projects.Owned": {"<-": "@repositoriesController.ownedRepositoriesContent.organizedContent"}
+                },
                 "listeners": [
                     {
                         "type": "openDocument",
@@ -169,7 +173,17 @@
                     "removalStrategy": "hide"
                 },
                 "bindings": {
-                    "condition": {"<-": "@historyProgress.max == @historyProgress.value && @owner.recentDocuments.length == 0"}
+                    "condition": {"<-": "@historyProgress.max == @historyProgress.value && @owner.projects.Owned.length == 0"}
+                }
+            },
+
+            "historyEmptyTitle": {
+                "prototype": "montage/ui/text.reel",
+                "properties": {
+                    "element": {"#": "historyEmptyTitle"}
+                },
+                "localizations": {
+                    "value": {"key": "empty_projects"}
                 }
             },
 
@@ -222,6 +236,9 @@
                 "bindings": {
                     "value": {
                         "<-": "@repositoryGroupList:iteration.object"
+                    },
+                    "enabled": {
+                        "<-": "@owner.projects[@repositoryGroupList:iteration.object.name].length != 0"
                     }
                 }
              },
@@ -309,7 +326,9 @@
                     </li>
                 </ul>
                 <div data-montage-id="historyProgress" class="History-progress"></div>
-                <div data-montage-id="historyEmpty">No Montage repositories where found :(</div>
+                <div data-montage-id="historyEmpty" class="History-empty">
+                    <span data-montage-id="historyEmptyTitle"></span>
+                </div>
                 <ul class="History-list" data-montage-id="historyList">
                     <li class="History-list-item" data-montage-id="historyListItem"></li>
                 </ul>

--- a/project-list/ui/main.reel/main.js
+++ b/project-list/ui/main.reel/main.js
@@ -9,8 +9,8 @@ exports.Main = Montage.create(Component, {
         value: "X"
     },
 
-    recentDocuments: {
-        value: null
+    projects: {
+        value: {}
     },
 
     isFirstRun: {


### PR DESCRIPTION
- rename "Recent Projects" to "Projects" and styled.
- change the message to "No Montage projects found" and styled it.
- disable both radio controls when no projects found.
- disable the recent radio control when no recents.
