### PR TITLE
Restore dragging and dropping throughout filament

### DIFF
--- a/ui/main.reel/main.js
+++ b/ui/main.reel/main.js
@@ -43,9 +43,12 @@ exports.Main = Montage.create(Component, {
 
             document.body.addEventListener("dragover", stop, false);
             document.body.addEventListener("drop", stop, false);
-            function stop(e) {
-                e.stopPropagation();
-                e.preventDefault();
+            function stop(evt) {
+                // Prevent "loading" dropped files as a browser is wont to do
+                if (evt.dataTransfer.types.indexOf("Files") > -1) {
+                    evt.stopPropagation();
+                    evt.preventDefault();
+                }
             }
         }
     },


### PR DESCRIPTION
We don't need to stop the defaults unless the drag is for a file
that would trigger the default behavior of navigating to the dropped
file.

Unchecked, this was preventing us from dragging and dropping text/plain
throughout the application into textfields that relied on the
default behavior.

Generally, we probably will want to also have some more specific
handling in these cases, but right now we do expect the default to
happen.
