### PR TITLE
Use EnvironmentBridge#read to load the package.json

### DIFF
--- a/core/project-controller.js
+++ b/core/project-controller.js
@@ -235,12 +235,11 @@ exports.ProjectController = ProjectController = DocumentController.specialize({
             this.packageUrl = packageUrl;
             this.dependencies = dependencies;
 
-            var packagePromise = require.loadPackage(this.packageUrl).then(function (packageRequire) {
-                var packageDescription = packageRequire.packageDescription;
+            var packagePromise = this.environmentBridge.read(this.packageUrl + "package.json").then(function (content) {
+                var packageDescription = JSON.parse(content);
                 self.loadProjectIcon(self.packageUrl);
                 self.packageDescription = packageDescription;
-                self._packageRequire = packageRequire;
-                self.projectDocument = new ProjectDocument().init(packageRequire, self, self.environmentBridge);
+                self.projectDocument = new ProjectDocument().init(self, self.environmentBridge);
 
                 // Add a dependency entry for this package so that the
                 // we pick up its extensions and components later

--- a/core/project-document.js
+++ b/core/project-document.js
@@ -68,11 +68,10 @@ exports.ProjectDocument = Document.specialize({
      * @param {Object} environmentBridge The backend service provider used to manipulate the package
      */
     init: {
-        value: function (packageRequire, documentController, environmentBridge) {
+        value: function (documentController, environmentBridge) {
             var self = this.super(),
                 bridge;
 
-            self._packageRequire = packageRequire;
             self._documentController = documentController;
             bridge = self._environmentBridge = environmentBridge;
 
@@ -98,33 +97,6 @@ exports.ProjectDocument = Document.specialize({
             window.pd = self;
 
             return self;
-        }
-    },
-
-    /**
-     * Returns a promise for the blueprint of the specified moduleId within the
-     * project's own package.
-     */
-    getBlueprintWithModuleId: {
-        value: function (moduleId) {
-
-            var packageRequire = this._packageRequire,
-                blueprintModuleId;
-
-            // TODO replace meta module naming with a more robust method; this may not be comprehensive enough
-            // It would be nice if montage itself offered an API that accounted for this
-            if (/\.reel$/.test(moduleId)) {
-                blueprintModuleId = moduleId.replace(/([\w-]+)\.reel$/, "$1.reel/$1.meta");
-            } else {
-                blueprintModuleId = moduleId.replace(/\.js$/, "");
-                blueprintModuleId += ".meta";
-            }
-
-            return packageRequire.async("montage/core/meta/module-blueprint")
-                .get("ModuleBlueprint")
-                .then(function (ModuleBlueprint) {
-                    return ModuleBlueprint.getBlueprintWithModuleId(blueprintModuleId, packageRequire);
-                });
         }
     },
 
@@ -408,9 +380,9 @@ exports.ProjectDocument = Document.specialize({
 // Constructor Properties
 {
     load: {
-        value: function (packageRequire, environmentBridge) {
+        value: function (environmentBridge) {
             var self = this;
-            return Promise.resolve((new self()).init(packageRequire, environmentBridge));
+            return Promise.resolve((new self()).init(environmentBridge));
         }
     },
 

--- a/test/mocks/environment-bridge-mocks.js
+++ b/test/mocks/environment-bridge-mocks.js
@@ -47,7 +47,8 @@ exports.environmentBridgeMock = function (options) {
         registerPreviewPromise = Promise.resolve(),
         launchPreviewPromise = Promise.resolve(),
         promptForSavePromise = Promise.resolve(),
-        getExtensionsAtPromise = Promise([]);
+        getExtensionsAtPromise = Promise([]),
+        readPromise = Promise("{}");
 
     Object.keys(options).forEach(function (key) {
         bridge[key] = options[key];
@@ -58,6 +59,7 @@ exports.environmentBridgeMock = function (options) {
     bridge.availableExtensions = Promise.resolve(options.extensionUrls || []);
     bridge.getExtensionsAt = options.getExtensionsAt || promiseFunction(getExtensionsAtPromise);
 
+    bridge.read = options.read || promiseFunction(readPromise);
     bridge.listTreeAtUrl = options.listTreeAtUrl || promiseFunction(listTreePromise);
     bridge.listAssetAtUrl = options.listAssetAtUrl || promiseFunction(listAssetAtUrl);
     bridge.detectMimeTypeAtUrl = options.detectMimeTypeAtUrl || promiseFunction(detectMimeTypeAtUrl);


### PR DESCRIPTION
Avoids errors when the cross domain cookie is not set. And it's just
more efficient in terms of network and memory, as we don't have to
create a whole new "package" object.
