### PR TITLE
Add support for displaying ICO files

### DIFF
--- a/extensions/image-viewer.filament-extension/extension.js
+++ b/extensions/image-viewer.filament-extension/extension.js
@@ -13,7 +13,7 @@ exports.Extension = CoreExtension.specialize( {
     editorFileMatchFunction: {
         enumerable: false,
         value : function (fileUrl) {
-            return (/\.jpg|png|gif|svg\/?$/).test(fileUrl);
+            return (/\.jpg|png|gif|svg|ico\/?$/).test(fileUrl);
         }
     },
 


### PR DESCRIPTION
And also unify the regular expression used to determine if a file is an image.

This PR depends on two backends ones:
https://github.com/declarativ/firefly/pull/97 [merged]
 and
https://github.com/declarativ/lumieres/pull/46
