### PR TITLE
Guard against renaming an object to the same label

### DIFF
--- a/core/reel-document.js
+++ b/core/reel-document.js
@@ -937,8 +937,10 @@ exports.ReelDocument = EditingDocument.specialize({
                     properties.element["#"] = montageId;
                 }
 
-                serializationObject[uniqueLabel] = serializationObject[label];
-                delete serializationObject[label];
+                if (uniqueLabel !== label) {
+                    serializationObject[uniqueLabel] = serializationObject[label];
+                    delete serializationObject[label];
+                }
             }
 
             template = new Template().initWithRequire(this._packageRequire);

--- a/test/core/reel-document-template-editing-spec.js
+++ b/test/core/reel-document-template-editing-spec.js
@@ -732,6 +732,27 @@ describe("core/reel-document-template-editing-spec", function () {
 
             }).timeout(WAITSFOR_TIMEOUT);
         });
+
+        it("uses an existing element with a data-montage-id that matches the library item label", function() {
+            return reelDocumentPromise.then(function (reelDocument) {
+                // setup
+                var nodeProxy = reelDocument.createTemplateNode('<p data-montage-id="fooSameMontageIdFoo"></p>');
+                reelDocument.appendChildToTemplateNode(nodeProxy);
+                expect(nodeProxy.isInTemplate).toBeTruthy();
+
+                // test
+                return reelDocument.insertTemplateObjectFromSerialization({
+                    "fooSameMontageIdFoo": {
+                        "prototype": "ui/foo.reel",
+                        "properties": {
+                            "element": {"#": "fooSameMontageIdFoo"}
+                        }
+                    }
+                }, nodeProxy).then(function (objects) {
+                    expect(objects[0].properties.get("element")).toBe(nodeProxy);
+                });
+            }).timeout(WAITSFOR_TIMEOUT);
+        });
     });
 
     describe("setting an object's label", function () {


### PR DESCRIPTION
When inserting a template object from a serialization we rename the
serialization object to the generated label for the component being
instantiated.
If the label happened to be the same of the library item then the object
would be deleted from the serialization by mistake.
