### PR TITLE
Improve project bootstrapping progress reporting

### DIFF
--- a/firefly-index.html
+++ b/firefly-index.html
@@ -61,7 +61,9 @@
                 "properties": {
                     "promptPanel": {"@": "promptPanel"},
                     "progressPanel": {"@": "progressPanel"},
-                    "confirmPanel": {"@": "confirmPanel"}
+                    "confirmPanel": {"@": "confirmPanel"},
+                    "initializeRepositoryPanel": {"@": "initializeRepoPanel"},
+                    "unknownRepositoryPanel": {"@": "unknownRepositoryPanel"}
                 }
             },
 

--- a/project-list/core/repositories-controller.js
+++ b/project-list/core/repositories-controller.js
@@ -39,26 +39,56 @@ var RepositoriesController = Montage.specialize({
     },
 
 
+    /**
+     * Open the specified repository by navigating to the expected URL
+     * @param {Object} repository The repository to open
+     */
     open: {
         value: function(repository) {
             window.location.pathname = "/" + repository.owner.login + "/" + repository.name;
         }
     },
 
+    /**
+     * Create a repository with the specified name and description
+     *
+     * @param {String} name The name of the repository to create
+     * @param {Object} options An object of key-value pair configuration options
+     * @return {Promise} A promise for the created repository
+     */
     createRepository: {
-        value: function(name, description) {
+        value: function(name, options) {
             var self = this;
 
             return this._githubApi.then(function(githubApi) {
-                return githubApi.createRepository(name, description)
+                return githubApi.createRepository(name, options)
                 .then(function(repo) {
                     /* jshint -W106 */
                     // This is the format expected by the github API, ignoring for now
                     repo.pushed_at = +new Date(repo.pushed_at);
                     /* jshint +W106 */
                     self._ownedRepositoriesContent.content.push(repo);
+                    return repo;
                 });
             });
+        }
+    },
+
+    /**
+     * Initialize the repository for the specified login with the specified repositoryName
+     *
+     * Note this does not validate that the repository specified exists or is receptive
+     * to being initialized with a montage project
+     *
+     * @param {String} ownerLogin The login name of the user
+     * @param {String} repositoryName The name of the repository to initialize
+     * @return {Promise} A promise for the initialized repository workspace
+     */
+    initializeRepository: {
+        value: function (ownerLogin, repositoryName) {
+            var repositoryController = new RepositoryController();
+            repositoryController.init(ownerLogin, repositoryName);
+            return repositoryController.initializeRepositoryWorkspace();
         }
     },
 


### PR DESCRIPTION
- [ ] Merge https://github.com/declarativ/firefly/pull/118

Foremost, we now start initializing a project immediately after we
have created the repository.

When landing on a projectUrl that is currently initializing we now
report as such, avoiding the need to manually trigger project creation
that is currently underway.

For completeness can now also trigger creating new repositories
when directly browsing to a projectUrl for a repository that does
not exist.

Error reporting should also be slightly improved as we now detect a
variety of other scenarios that you might end up in and report
more specific errors to the user.
