### PR TITLE
Fix: Code Editor doesn't show cursor after switching tabs

### DIFF
--- a/extensions/code-editor.filament-extension/ui/code-editor.reel/code-editor.js
+++ b/extensions/code-editor.filament-extension/ui/code-editor.reel/code-editor.js
@@ -197,6 +197,7 @@ var CodeEditor = exports.CodeEditor = Editor.specialize ({
     didDraw: {
         value: function() {
             this._codeMirror.refresh();
+            this._codeMirror.focus();
         }
     },
 


### PR DESCRIPTION
![cursor](https://cloud.githubusercontent.com/assets/55838/2606084/a49a7dca-bb4b-11e3-8b99-10031c85f3ea.gif)

https://montage.atlassian.net/browse/FIL-444
