### PR TITLE
Prevent creating a binding with no source path and no target path

### DIFF
--- a/core/reel-document.js
+++ b/core/reel-document.js
@@ -1339,6 +1339,10 @@ exports.ReelDocument = EditingDocument.specialize({
 
     defineOwnedObjectBinding: {
         value: function (proxy, targetPath, oneway, sourcePath, converter) {
+            if (!this.isBindingParamsValid(targetPath, sourcePath)) {
+                return null;
+            }
+
             var binding = proxy.defineObjectBinding(targetPath, oneway, sourcePath, converter);
 
             if (binding) {
@@ -1407,8 +1411,18 @@ exports.ReelDocument = EditingDocument.specialize({
         }
     },
 
+    isBindingParamsValid: {
+        value: function(targetPath, sourcePath) {
+            return targetPath && sourcePath;
+        }
+    },
+
     updateOwnedObjectBinding: {
         value: function (proxy, existingBinding, targetPath, oneway, sourcePath, converter) {
+            if (!this.isBindingParamsValid(targetPath, sourcePath)) {
+                return null;
+            }
+
             var originalTargetPath = existingBinding.targetPath,
                 originalOneway = existingBinding.oneway,
                 originalSourcePath = existingBinding.sourcePath,

--- a/ui/binding-jig.reel/binding-jig.js
+++ b/ui/binding-jig.reel/binding-jig.js
@@ -154,6 +154,9 @@ exports.BindingJig = Montage.create(Component, {
                 bindingEntry = this.editingDocument.defineOwnedObjectBinding(proxy, targetPath, oneway, sourcePath, converter);
             }
 
+            if (!bindingEntry) {
+                return;
+            }
 
             this.dispatchEventNamed("commit", true, false, {
                 bindingEntry: bindingEntry


### PR DESCRIPTION
Creating:
![empty](https://cloud.githubusercontent.com/assets/55838/2659040/d85577e6-c00f-11e3-8efc-1f6e1f6e3c08.gif)

Editing:
![empty2](https://cloud.githubusercontent.com/assets/55838/2659043/db5612a2-c00f-11e3-88ea-1008e8bf5f59.gif)

https://montage.atlassian.net/browse/FIL-450
