### PR TITLE
Stop template explorer tab switch jerkiness

### DIFF
--- a/ui/component-editor.reel/component-editor.html
+++ b/ui/component-editor.reel/component-editor.html
@@ -81,7 +81,8 @@
             "templateExplorer": {
                 "prototype": "ui/template-explorer.reel",
                 "properties": {
-                    "element": {"#": "templateExplorer"}
+                    "element": {"#": "templateExplorer"},
+                    "_blocksOwnerComponentDraw": true
                 },
                 "bindings": {
                     "ownerObject": {"<-": "@owner.currentDocument.editingProxyMap.owner"},

--- a/ui/template-explorer.reel/template-explorer.html
+++ b/ui/template-explorer.reel/template-explorer.html
@@ -75,7 +75,8 @@
         "templateObjectCell": {
             "prototype": "./template-object-cell.reel",
             "properties": {
-                "element": {"#": "templateObjectCell"}
+                "element": {"#": "templateObjectCell"},
+                "_blocksOwnerComponentDraw": true
             },
             "bindings": {
                 "showBindings": {"<-": "@owner.showBindings"},


### PR DESCRIPTION
Makes the component editor wait for the template explorer to draw.
And make the template explorer wait on template object cell to draw.

before:
![before](https://cloud.githubusercontent.com/assets/78122/2677034/46699f4e-c148-11e3-9a94-10484f87543d.gif)

after:
![after](https://cloud.githubusercontent.com/assets/78122/2677035/49bed010-c148-11e3-9cd1-6e0e336f2d0b.gif)
