### PR TITLE
Fix scrollbars styling

### DIFF
--- a/assets/styles/filament-components.css
+++ b/assets/styles/filament-components.css
@@ -43,16 +43,28 @@
   cursor: pointer;
 }
 
-.Search.matte-InputText::-webkit-search-cancel-button:hover,
-.Search.matte-InputText::-moz-search-cancel-button:hover,
-.Search.matte-InputText::-ms-search-cancel-button:hover,
+.Search.matte-InputText::-webkit-search-cancel-button:hover {
+    opacity: 1;
+}
+.Search.matte-InputText::-moz-search-cancel-button:hover {
+    opacity: 1;
+}
+.Search.matte-InputText::-ms-search-cancel-button:hover {
+    opacity: 1;
+}
 .Search.matte-InputText::search-cancel-button:hover {
   opacity: 1;
 }
 
-.Search.matte-InputText::-webkit-search-cancel-button:active,
-.Search.matte-InputText::-moz-search-cancel-button:active,
-.Search.matte-InputText::-ms-search-cancel-button:active,
+.Search.matte-InputText::-webkit-search-cancel-button:active {
+    opacity: .3;
+}
+.Search.matte-InputText::-moz-search-cancel-button:active {
+    opacity: .3;
+}
+.Search.matte-InputText::-ms-search-cancel-button:active {
+    opacity: .3;
+}
 .Search.matte-InputText::search-cancel-button:active {
   opacity: .3;
 }

--- a/assets/styles/filament.css
+++ b/assets/styles/filament.css
@@ -35,22 +35,46 @@ body {
 
 /* Scrollbar -------------------------------- */
 
-::-webkit-scrollbar,
-::-moz-scrollbar,
-::-ms-scrollbar,
-::scrollbar {
+::-webkit-scrollbar {
     -webkit-appearance: none;
+    width: 8px;
+    height: 0px;
+    background-color: hsla(0,0%,0%,0);
+}
+::-moz-scrollbar {
     -moz-appearance: none;
+    width: 8px;
+    height: 0px;
+    background-color: hsla(0,0%,0%,0);
+}
+::-ms-scrollbar {
     -ms-appearance: none;
+    width: 8px;
+    height: 0px;
+    background-color: hsla(0,0%,0%,0);
+}
+::scrollbar {
     appearance: none;
     width: 8px;
     height: 0px;
     background-color: hsla(0,0%,0%,0);
 }
 
-::-webkit-scrollbar-thumb,
-::-moz-scrollbar-thumb,
-::-ms-scrollbar-thumb,
+::-webkit-scrollbar-thumb {
+    border-left: 6px solid hsla(0, 0%, 0%, 0);
+    background-clip: padding-box;
+    background-color: hsla(0, 0%, 0%, 0.15);
+}
+::-moz-scrollbar-thumb {
+    border-left: 6px solid hsla(0, 0%, 0%, 0);
+    background-clip: padding-box;
+    background-color: hsla(0, 0%, 0%, 0.15);
+}
+::-ms-scrollbar-thumb {
+    border-left: 6px solid hsla(0, 0%, 0%, 0);
+    background-clip: padding-box;
+    background-color: hsla(0, 0%, 0%, 0.15);
+}
 ::scrollbar-thumb {
     border-left: 6px solid hsla(0, 0%, 0%, 0);
     background-clip: padding-box;

--- a/ui/configurator.reel/configurator.css
+++ b/ui/configurator.reel/configurator.css
@@ -80,22 +80,43 @@
 
 /* Scrollbar -------------------------------- */
 
-.BlueprintEditor::-webkit-scrollbar,
-.BlueprintEditor::-moz-scrollbar,
-.BlueprintEditor::-ms-scrollbar,
-.BlueprintEditor::scrollbar {
+.BlueprintEditor::-webkit-scrollbar {
     -webkit-appearance: none;
+    width: 3px;
+    height: 0px;
+    background-color: hsl(0, 0%, 70%);
+}
+.BlueprintEditor::-moz-scrollbar {
     -moz-appearance: none;
+    width: 3px;
+    height: 0px;
+    background-color: hsl(0, 0%, 70%);
+}
+.BlueprintEditor::-ms-scrollbar {
     -ms-appearance: none;
+    width: 3px;
+    height: 0px;
+    background-color: hsl(0, 0%, 70%);
+}
+.BlueprintEditor::scrollbar {
     appearance: none;
     width: 3px;
     height: 0px;
     background-color: hsl(0, 0%, 70%);
 }
 
-.BlueprintEditor::-webkit-scrollbar-thumb,
-.BlueprintEditor::-moz-scrollbar-thumb,
-.BlueprintEditor::-ms-scrollbar-thumb,
+.BlueprintEditor::-webkit-scrollbar-thumb {
+    border: none;
+    background-color: hsl(0, 0%, 90%);
+}
+.BlueprintEditor::-moz-scrollbar-thumb {
+    border: none;
+    background-color: hsl(0, 0%, 90%);
+}
+.BlueprintEditor::-ms-scrollbar-thumb {
+    border: none;
+    background-color: hsl(0, 0%, 90%);
+}
 .BlueprintEditor::scrollbar-thumb {
     border: none;
     background-color: hsl(0, 0%, 90%);

--- a/ui/library.reel/library.css
+++ b/ui/library.reel/library.css
@@ -189,22 +189,43 @@
 
 /* Scrollbar -------------------------------- */
 
-.Library ::-webkit-scrollbar,
-.Library ::-moz-scrollbar,
-.Library ::-ms-scrollbar,
-.Library ::scrollbar {
+.Library ::-webkit-scrollbar {
     -webkit-appearance: none;
+    width: 3px;
+    height: 0px;
+    background-color: hsl(0, 0%, 18%);
+}
+.Library ::-moz-scrollbar {
     -moz-appearance: none;
+    width: 3px;
+    height: 0px;
+    background-color: hsl(0, 0%, 18%);
+}
+.Library ::-ms-scrollbar {
     -ms-appearance: none;
+    width: 3px;
+    height: 0px;
+    background-color: hsl(0, 0%, 18%);
+}
+.Library ::scrollbar {
     appearance: none;
     width: 3px;
     height: 0px;
     background-color: hsl(0, 0%, 18%);
 }
 
-.Library ::-webkit-scrollbar-thumb,
-.Library ::-moz-scrollbar-thumb,
-.Library ::-ms-scrollbar-thumb,
+.Library ::-webkit-scrollbar-thumb {
+    border: none;
+    background-color: hsl(0, 0%, 32%);
+}
+.Library ::-moz-scrollbar-thumb {
+    border: none;
+    background-color: hsl(0, 0%, 32%);
+}
+.Library ::-ms-scrollbar-thumb {
+    border: none;
+    background-color: hsl(0, 0%, 32%);
+}
 .Library ::scrollbar-thumb {
     border: none;
     background-color: hsl(0, 0%, 32%);


### PR DESCRIPTION
Browsers are not able to ignore invalid css selectors when they are 
separated by comma, they entire block is ignored.
