### PR TITLE
Add quick button for private repository access

### DIFF
--- a/project-list/core/repositories-controller.js
+++ b/project-list/core/repositories-controller.js
@@ -378,6 +378,18 @@ var RepositoriesController = Montage.specialize({
         }
     },
 
+    clearCachedRepositories: {
+        value: function () {
+            this.repositoriesCount = 0;
+            localStorage.removeItem(LOCAL_STORAGE_REPOSITORIES_COUNT_KEY);
+
+            this.processedRepositories = 0;
+            localStorage.removeItem(LOCAL_STORAGE_KEY);
+
+            return Promise();
+        }
+    },
+
     updateAndCacheUserRepositories: {
         value: function () {
             var self = this;

--- a/project-list/ui/main.reel/main.css
+++ b/project-list/ui/main.reel/main.css
@@ -217,6 +217,10 @@
     border: none !important;
 }
 
+.Launcher .Button {
+    margin: 0.5em 0;
+}
+
 /* Action --------------------------------- */
 
 .Launcher-section .Action {

--- a/project-list/ui/main.reel/main.html
+++ b/project-list/ui/main.reel/main.html
@@ -285,6 +285,17 @@
                     }
                 }
             },
+
+            "authorizePrivateAccessButton": {
+                "prototype": "matte/ui/button.reel",
+                "properties": {
+                    "element": {"#": "authorizePrivateAccessButton"}
+                },
+                "listeners": [
+                    {"type": "action", "listener": {"@": "owner"}}
+                ]
+            },
+
             "repositoriesController": {
                 "prototype": "../../core/repositories-controller"
             },
@@ -382,6 +393,8 @@
                     <li class="History-list-item" data-montage-id="historyListItem"></li>
                 </ul>
             </section>
+
+            <button data-montage-id="authorizePrivateAccessButton" class="Button">Authorize private repository access</button>
 
             <button data-montage-id="removeWorkspaces" class="Button"></button>
 

--- a/project-list/ui/main.reel/main.js
+++ b/project-list/ui/main.reel/main.js
@@ -187,6 +187,16 @@ exports.Main = Montage.create(Component, {
         }
     },
 
+    handleAuthorizePrivateAccessButtonAction: {
+        value: function () {
+            this.templateObjects.repositoriesController.clearCachedRepositories()
+                .finally(function () {
+                    window.location = "/auth/github/private";
+                })
+                .done();
+        }
+    },
+
     _createNewApplication: {
         value: function () {
             var templateObjects = this.templateObjects,


### PR DESCRIPTION
This is certainly not final, this page is currently being redesigned,
I'm doing this much to make sure that when we downgrade to public
repo access by default we can still let some users decide to upgrade.

We should only show this if the user is not already able to see
private repositories
- [x] Depends on https://github.com/declarativ/firefly/pull/174
