### PR TITLE
Add component button back to package explorer

### DIFF
--- a/ui/package-explorer.reel/package-explorer.css
+++ b/ui/package-explorer.reel/package-explorer.css
@@ -131,3 +131,59 @@
     overflow-y: scroll;
     background-color: #424242;
 }
+
+/* PackageExplorer footer ------------------- */
+
+.PackageExplorer-footer {
+    background: -webkit-linear-gradient( hsl(0,0%,96%), hsl(0,0%,92%) );
+    background: -moz-linear-gradient( hsl(0,0%,96%), hsl(0,0%,92%) );
+    background: -ms-linear-gradient( hsl(0,0%,96%), hsl(0,0%,92%) );
+    background: linear-gradient( hsl(0,0%,96%), hsl(0,0%,92%) );
+}
+
+.PackageExplorer-footer-button:before {
+    content: "+";
+    position: relative;
+    top: 1px;
+    margin-right: 4px;
+    line-height: 0;
+    font-size: 18px;
+    font-weight: bold;
+    -webkit-font-smoothing: none;
+    -moz-font-smoothing: none;
+    -ms-font-smoothing: none;
+    font-smoothing: none;
+    color: hsl(0, 0%, 70%);
+}
+
+.PackageExplorer-footer-button.matte-Button {
+    display: block;
+    position: relative;
+    width: 100%;
+    height: auto;
+    margin: 0;
+    padding: 8px;
+    font-family: inherit;
+    font-weight: 600;
+    font-size: 13px;
+    color: hsl(0, 0%, 66%);
+    border-radius: 0;
+    border: none;
+    border-top: 1px solid hsl(0, 0%, 36%);
+    box-shadow: none;
+    background-color: hsl(0, 0%, 32%);
+}
+
+.PackageExplorer-footer-button.matte-Button:hover {
+    color: hsl(0, 0%, 81%);
+    background-color: hsl(0, 0%, 36%);
+}
+
+.PackageExplorer-footer-button.matte-Button.active {
+    border-color:  hsl(0, 0%, 22%);
+    background-color: hsl(0, 0%, 24%);
+}
+
+.PackageExplorer-footer-button.matte-Button:focus {
+    border-color: hsl(0, 0%, 22%);
+}

--- a/ui/package-explorer.reel/package-explorer.html
+++ b/ui/package-explorer.reel/package-explorer.html
@@ -89,6 +89,22 @@
                     "projectController": {"<-": "@owner.projectController"},
                     "classList.has('contextualMenu-selection')": {"<-": "@owner.templateObjects.contextualMenu.fileInfo == fileInfo"}
                 }
+            },
+
+            "addComponentButton": {
+                "prototype": "matte/ui/button.reel",
+                "properties": {
+                    "element": {"#": "addComponentButton"}
+                },
+                "localizations": {
+                    "label": {"key": "add_component"}
+                },
+                "listeners": [
+                    {
+                        "type": "action",
+                        "listener": {"@": "owner"}
+                    }
+                ]
             }
         }
     </script>
@@ -109,6 +125,10 @@
         <div data-montage-id="fileList" class="PackageExplorer-list">
             <span data-montage-id="file-cell" data-arg="treeNode"></span>
         </div>
+        <div class="Shadow Shadow--bottom"></div>
+        <footer class="PackageExplorer-footer">
+            <button data-montage-id="addComponentButton" class="PackageExplorer-footer-button" title="Add a new component to the project's ui directory">Component</button>
+        </footer>
     </div>
 
 </body>

--- a/ui/package-explorer.reel/package-explorer.js
+++ b/ui/package-explorer.reel/package-explorer.js
@@ -293,6 +293,12 @@ exports.PackageExplorer = Component.specialize({
             this.isShown = !this.isShown;
             this._menuItem.title = this.isShown ? HIDE_MENU_TEXT : SHOW_MENU_TEXT;
         }
+    },
+
+    handleAddComponentButtonAction: {
+        value: function (evt) {
+            this.dispatchEventNamed("addFile", true, true);
+        }
     }
 
 });


### PR DESCRIPTION
This is one of the most central and crucial parts of building a Montage application, it shouldn't be hidden in menus and sub-menus at 5 clicks away, it should be as easy as a one click operation.
I believe the reason almost no one is creating components is because there's nothing hinting them that that's what they should be doing.
If we want the user to do something it should be right there in the screen for them to do.
