### PR TITLE
Fix an issue when rendering a Scene within the SceneEditor

### DIFF
--- a/extensions/collada.filament-extension/ui/editor.reel/stage-3D.reel/stage-3D.js
+++ b/extensions/collada.filament-extension/ui/editor.reel/stage-3D.reel/stage-3D.js
@@ -132,7 +132,7 @@ exports.Stage3D = Component.specialize(/** @lends Stage3D# */ {
             if (this._scene) {
                 var id = reelProxy.properties.get('id');
 
-                if (id !== null) {
+                if (id) {
                     element = this._scene.glTFElement.ids[id];
                 }
             }
@@ -145,7 +145,7 @@ exports.Stage3D = Component.specialize(/** @lends Stage3D# */ {
         value: function (reelProxy) {
             var element = this._elementForReelProxy(reelProxy);
 
-            if (element !== null && element.component3D === null) {
+            if (element && element.component3D) {
                 element.component3D = this._fullfilComponent3D(new Material(), reelProxy.properties);
             }
         }
@@ -155,7 +155,7 @@ exports.Stage3D = Component.specialize(/** @lends Stage3D# */ {
         value: function (reelProxy) {
             var element = this._elementForReelProxy(reelProxy);
 
-            if (element !== null && element.component3D === null) {
+            if (element && element.component3D) {
                 element.component3D = this._fullfilComponent3D(new Node(), reelProxy.properties);
             }
         }


### PR DESCRIPTION
When the Stage3D applies the values ​​contained in the related editing Proxies to the 3D nodes of a Scene, we need to check that the id property has been set, in order to get the 3D node.
