### PR TITLE
Add compatibility file

### DIFF
--- a/core/compatibility.js
+++ b/core/compatibility.js
@@ -1,0 +1,9 @@
+/* global DOMStringList */
+
+// Firefox uses DOMStringList for dataTransfer.types
+if (typeof DOMStringList === "object") {
+    DOMStringList.prototype.indexOf = Array.prototype.indexOf;
+    DOMStringList.prototype.has = Array.prototype.has;
+    DOMStringList.prototype.find = Array.prototype.find;
+    DOMStringList.prototype.forEach = Array.prototype.forEach;
+}

--- a/ui/main.reel/main.js
+++ b/ui/main.reel/main.js
@@ -2,6 +2,9 @@ var Montage = require("montage/core/core").Montage,
     Component = require("montage/ui/component").Component,
     application = require("montage/core/application").application;
 
+// Browser Compatibility
+require("core/compatibility");
+
 exports.Main = Montage.create(Component, {
 
     projectController: {


### PR DESCRIPTION
So far we only need to patch over Firefox's DOMStringList usage in the
dataTransfer.types collection as part of drag and drop.
