### PR TITLE
Rename willSave & didSave events to willSaveProject & didSaveProject

### DIFF
--- a/core/preview-controller.js
+++ b/core/preview-controller.js
@@ -36,7 +36,7 @@ exports.PreviewController = Target.specialize({
 
             var app = require("montage/core/application").application;
 
-            app.addEventListener("didSave", this);
+            app.addEventListener("didSaveProject", this);
             app.addEventListener("didSetOwnedObjectProperties", this);
             app.addEventListener("didSetOwnedObjectProperty", this);
             app.addEventListener("didSetOwnedObjectLabel", this);
@@ -309,7 +309,7 @@ exports.PreviewController = Target.specialize({
 
     //// LISTENERS
 
-    handleDidSave: {
+    handleDidSaveProject: {
         value: function () {
             this.refreshPreview().done();
             if (typeof this.environmentBridge.didSaveProject === "function") {

--- a/core/project-controller.js
+++ b/core/project-controller.js
@@ -1158,7 +1158,7 @@ exports.ProjectController = ProjectController = DocumentController.specialize({
                 savePromise;
 
             if (this.currentDocument) {
-                this.dispatchEventNamed("willSave", true, false);
+                this.dispatchEventNamed("willSaveProject", true, false);
 
                 savePromise = this.projectDocument.saveAll()
                     .then(function (result) {
@@ -1167,7 +1167,7 @@ exports.ProjectController = ProjectController = DocumentController.specialize({
                             self.environmentBridge.setDocumentDirtyState(false);
                         }
 
-                        self.dispatchEventNamed("didSave", true, false);
+                        self.dispatchEventNamed("didSaveProject", true, false);
                         return result;
                     });
             }


### PR DESCRIPTION
This will reduce preview flickers due to unnecessary reloading.

Note: willSave and didSave events are already used by the code editor on
a per document basis for internal purpose
