### PR TITLE
https://montage.atlassian.net/browse/FIL-559

### DIFF
--- a/extensions/collada.filament-extension/ui/editor.reel/stage-3D.reel/stage-3D.js
+++ b/extensions/collada.filament-extension/ui/editor.reel/stage-3D.reel/stage-3D.js
@@ -145,7 +145,7 @@ exports.Stage3D = Component.specialize(/** @lends Stage3D# */ {
         value: function (reelProxy) {
             var element = this._elementForReelProxy(reelProxy);
 
-            if (element && element.component3D) {
+            if (element) {
                 element.component3D = this._fullfilComponent3D(new Material(), reelProxy.properties);
             }
         }
@@ -155,7 +155,7 @@ exports.Stage3D = Component.specialize(/** @lends Stage3D# */ {
         value: function (reelProxy) {
             var element = this._elementForReelProxy(reelProxy);
 
-            if (element && element.component3D) {
+            if (element) {
                 element.component3D = this._fullfilComponent3D(new Node(), reelProxy.properties);
             }
         }


### PR DESCRIPTION
Values are now set as expected on the highest level 3d entities (node,material) instead of their low level counter part (glTF-node,glTF-material) so that events are dispatched whenever a change happens and the view has the opportunity to refresh.
