### PR TITLE
Use childNodes instead of children on DocumentFragment

### DIFF
--- a/core/reel-document.js
+++ b/core/reel-document.js
@@ -1104,9 +1104,11 @@ exports.ReelDocument = EditingDocument.specialize({
             sourceContentFragment = sourceContentRange.cloneContents();
 
             newChildNodes = [];
-            //TODO do we want children or childNodes (textnodes included)?
-            for (i = 0; (iChild = sourceContentFragment.children[i]); i++) {
-                newChildNodes.push(iChild);
+            for (i = 0; (iChild = sourceContentFragment.childNodes[i]); i++) {
+                //TODO do we want children or childNodes (textnodes included)?
+                if (iChild.nodeType === Node.ELEMENT_NODE) {
+                    newChildNodes.push(iChild);
+                }
             }
 
             // Merge markup


### PR DESCRIPTION
Safari doesn't implement children in DocumentFragments

Fixes https://rollbar.com/declarativ/Filament/items/1223/
