### PR TITLE
Implement an undoManager for editorFields

### DIFF
--- a/ui/text-editor-field.reel/text-editor-field.html
+++ b/ui/text-editor-field.reel/text-editor-field.html
@@ -22,7 +22,8 @@
         "inputText": {
             "prototype": "matte/ui/input-text.reel",
             "properties": {
-                "element": {"#": "inputText"}
+                "element": {"#": "inputText"},
+                "delegate": {"@": "owner"}
             },
             "bindings": {
                 "value": {"<->": "@owner._inputValue"}


### PR DESCRIPTION
This puts us in charge of undoability within editorFields instead of
relying on the native undo within text inputs.

In addition to putting us a step closer to being able to use the native
undo keyboard shortcut as we're closer to the native expectations, this
also addresses the issue where you could be editing an object you just 
added and then undo its addition, which was…unfortunate.

Now you can't delete the object out from under you by way of undoing
its addition.

https://montage.atlassian.net/browse/FIL-568
