### PR TITLE
Don't track url in "Loading project" message...

### DIFF
--- a/core/firefly-application-delegate.js
+++ b/core/firefly-application-delegate.js
@@ -199,7 +199,7 @@ exports.FireflyApplicationDelegate = ApplicationDelegate.specialize({
                 self.currentPanelKey = "progress";
                 self.progressPanel.message = "Loading project…";
                 self.showModal = true;
-                track.message("Loading project " + projectUrl);
+                track.message("loading project");
                 superMethod.call(self, projectUrl)
                 .then(deferred.resolve)
                 .fail(loadProjectFail)


### PR DESCRIPTION
...as the unique message creates a new item in Rollbar. The metadata
of the message includes the URL of the project that is being loaded
