### PR TITLE
Add checks for dataTransfer.types on drag ops

### DIFF
--- a/ui/binding-jig.reel/binding-jig.js
+++ b/ui/binding-jig.reel/binding-jig.js
@@ -76,7 +76,7 @@ exports.BindingJig = Montage.create(Component, {
 
     handleDrop: {
         value: function (event) {
-            if (event.dataTransfer.types.has(MimeTypes.SERIALIZATION_OBJECT_LABEL)) {
+            if (event.dataTransfer.types && event.dataTransfer.types.has(MimeTypes.SERIALIZATION_OBJECT_LABEL)) {
                 var plain = event.dataTransfer.getData("text/plain");
                 var rich = "@" + event.dataTransfer.getData(MimeTypes.SERIALIZATION_OBJECT_LABEL);
                 replaceDroppedTextPlain(plain, rich, this.templateObjects.sourcePath.element);

--- a/ui/main.reel/main.js
+++ b/ui/main.reel/main.js
@@ -56,7 +56,7 @@ exports.Main = Montage.create(Component, {
             document.body.addEventListener("drop", stop, false);
             function stop(evt) {
                 // Prevent "loading" dropped files as a browser is wont to do
-                if (evt.dataTransfer.types.indexOf("Files") > -1) {
+                if (evt.dataTransfer.types && evt.dataTransfer.types.indexOf("Files") > -1) {
                     evt.stopPropagation();
                     evt.preventDefault();
                 }

--- a/ui/package-explorer.reel/file-cell.reel/file-cell.js
+++ b/ui/package-explorer.reel/file-cell.reel/file-cell.js
@@ -209,7 +209,7 @@ exports.FileCell = Montage.create(Component, {
 
     captureDragenter: {
         value: function(e) {
-            if (e.dataTransfer.types.indexOf("Files") === -1) {
+            if (e.dataTransfer.types && e.dataTransfer.types.indexOf("Files") === -1) {
                 return;
             }
             e.stopPropagation();


### PR DESCRIPTION
Safari leaves this null in situations where there's no type registered
so we need to expect that types might be null and not the StringList
we expect.
