### PR TITLE
Allow to open and edit a generic text file with Montage Studio

### DIFF
--- a/extensions/code-editor.filament-extension/core/code-editor-document.js
+++ b/extensions/code-editor.filament-extension/core/code-editor-document.js
@@ -344,6 +344,8 @@ var CodeEditorDocument = exports.CodeEditorDocument = Document.specialize({
                 return "x-shader/x-fragment";
             } else if (CodeEditorDocument.editorFileMatchMarkdown(fileUrl)) {
                 return "text/plain";
+            } else if (CodeEditorDocument.editorFileMatchText(fileUrl)) {
+                return "text/plain";
             }
             return null;
         }
@@ -388,6 +390,13 @@ var CodeEditorDocument = exports.CodeEditorDocument = Document.specialize({
         enumerable:false,
         value:function (fileUrl) {
             return (/\.md\/?$/).test(fileUrl);
+        }
+    },
+
+    editorFileMatchText:{
+        enumerable:false,
+        value:function (fileUrl) {
+            return (/\.txt\/?$/).test(fileUrl);
         }
     },
 


### PR DESCRIPTION
This is a limitation that has bug me for a while :-)

Note: MS does not give you the opportunity to create a text file, however
a text file might have been created with an external tool.
