### PR TITLE
Add array functions to DOMStringList

### DIFF
--- a/ui/drag-and-drop.js
+++ b/ui/drag-and-drop.js
@@ -1,5 +1,13 @@
 var Promise = require("montage/core/promise").Promise;
 
+// Firefox uses DOMStringList for dataTransfer.types
+if (typeof DOMStringList === "object") {
+    DOMStringList.prototype.indexOf = Array.prototype.indexOf;
+    DOMStringList.prototype.has = Array.prototype.has;
+    DOMStringList.prototype.find = Array.prototype.find;
+    DOMStringList.prototype.forEach = Array.prototype.forEach;
+}
+
 /**
  * Because a text field takes the text/plain data from a drop event, we need to
  * go in afterwards and instead use the content we want.


### PR DESCRIPTION
dataTransfer old interface is defined as a DOMStringList[], this 
has been change to an array of strings recently.
Since DOMStringList is lacking several methods from the Array interface
we need to patch the DOMStringList so we can treat it like an Array.

https://bugs.webkit.org/show_bug.cgi?id=30416
