### PR TITLE
Revert dom explorer to old tree list component

### DIFF
--- a/ui/dom-explorer.reel/dom-explorer.css
+++ b/ui/dom-explorer.reel/dom-explorer.css
@@ -20,21 +20,13 @@
     min-height: 0;
 }
 
-.NodeList.TreeList {
+.NodeList .Tree-list {
     padding: 12px;
     padding-bottom: 30px;
     font-size: 13px;
-}
-
-.NodeList .TreeList-repetition {
-    position: relative;
-}
-
-.NodeList .TreeListNodeWrapper:first-child {
     background: linear-gradient( to right, hsl(0,0%,86%) 0px, hsl(0,0%,86%) 1px, hsla(0,0%,86%,0) 1px );
-    background-size: 20px;
+    background-size: 18px;
     background-clip: content-box;
-    background-position: 6px;
 }
 
 .DomExplorer .NodeList .Tree-list-row {

--- a/ui/dom-explorer.reel/dom-explorer.html
+++ b/ui/dom-explorer.reel/dom-explorer.html
@@ -51,25 +51,24 @@
         },
 
         "nodeTreeController": {
-            "prototype": "montage/core/tree-controller",
+            "prototype": "core/tree-controller",
             "properties": {
+                "childrenPath": "children",
                 "initiallyExpanded": true
             },
             "bindings": {
-                "data": {"<-": "@owner.editingDocument.templateBodyNode.children.0"}
+                "content": {"<-": "@owner.editingDocument.templateBodyNode.children.0"}
             }
         },
 
         "nodeList": {
-            "prototype": "montage/ui/tree-list.reel",
+            "prototype": "ui/tree.reel",
             "properties": {
                 "element": {"#": "nodeList"},
-                "isSelectionEnabled": false,
-                "indentationWidth": 20,
-                "rowHeight": 30
+                "isSelectionEnabled": false
             },
             "bindings": {
-                "controller": {"<-": "@owner.nodeTreeController"}
+                "treeController": {"<-": "@owner.nodeTreeController"}
             }
         },
 
@@ -80,7 +79,7 @@
                 "domExplorer": {"@": "owner"}
             },
             "bindings": {
-                "info": {"<-": "@nodeList:iteration.object"},
+                "data": {"<-": "@nodeCell.parentComponent.iteration"},
                 "domExplorer": {"<-": "@owner"}
             }
         },
@@ -120,7 +119,7 @@
 <body>
     <div data-montage-id="dom-explorer" class="DomExplorer preshift">
         <div data-montage-id="nodeList" class="NodeList">
-            <div data-montage-id="nodeCell"></div>
+            <div data-montage-id="nodeCell" data-arg="treeNode"></div>
         </div>
         <footer data-montage-id="drawer">
             <div data-montage-id="createNodeCell" data-arg="createElement"></div>

--- a/ui/dom-explorer.reel/node-cell.reel/node-cell.html
+++ b/ui/dom-explorer.reel/node-cell.reel/node-cell.html
@@ -179,7 +179,7 @@
                 "element": {"#": "toggleExpanded"}
             },
             "bindings": {
-                "checked": {"<->": "@owner.treeControllerNode.isExpanded"},
+                "checked": {"<->": "@owner.isExpanded"},
                 "label": {"<-": "'Expanded'"}
             }
         },

--- a/ui/dom-explorer.reel/node-cell.reel/node-cell.js
+++ b/ui/dom-explorer.reel/node-cell.reel/node-cell.js
@@ -94,6 +94,25 @@ exports.NodeCell = Component.specialize(/** @lends module:"./node-cell.reel".Nod
         }
     },
 
+    _isExpanded: {
+        value: null
+    },
+
+    isExpanded: {
+        get: function() {
+            return this._isExpanded;
+        },
+        set: function(value) {
+            if (this._isExpanded !== value) {
+                this._isExpanded = value;
+                if (this.treeControllerNode &&
+                    this.treeControllerNode.expanded !== value) {
+                    this.treeControllerNode.expanded = value;
+                }
+            }
+        }
+    },
+
     enterDocument: {
         value: function (firstTime) {
             if (!firstTime) { return; }
@@ -469,20 +488,21 @@ exports.NodeCell = Component.specialize(/** @lends module:"./node-cell.reel".Nod
     },
 
     /// MANUAL BINDINGS
-    _info: {
+    _data: {
         value: null
     },
 
-    info: {
+    data: {
         get: function() {
-            return this._info;
+            return this._data;
         },
         set: function(value) {
-            if (value !== this._info) {
-                this._info = value;
+            if (value !== this._data) {
+                this._data = value;
                 if (value) {
                     this.treeControllerNode = value;
-                    this.nodeInfo = value.data;
+                    this.nodeInfo = value.content;
+                    this.isExpanded = value.expanded;
                 } else {
                     this.treeControllerNode = null;
                     this.nodeInfo = null;


### PR DESCRIPTION
New tree list causes differences in styling and doesn't support things like auto expanding nodes. Since this dom explorer is going to go away in the near future anyway I'm reverting it to the stable version for demoing purposes.